### PR TITLE
Baseline bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ We have separate files describing the [datasets](./data/), [systems](./systems/)
 
 Version | Description
 ------- | -------------
+2       | Data with fixes for variables incorrectly defined in questions
 1       | Data used in the ACL 2018 paper
 
 # Citing this work

--- a/data/advising.json
+++ b/data/advising.json
@@ -14355,7 +14355,7 @@
             },
             {
                 "question-split": "test",
-                "text": "Is there a level level0 , c400redit0 -credit department0 course ?",
+                "text": "Is there a level level0 , credit0 -credit department0 course ?",
                 "variables": {
                     "credit0": "12",
                     "department0": "SEAS",
@@ -25073,12 +25073,12 @@
             },
             {
                 "question-split": "train",
-                "text": "Is any department0 number0 section scheduled between 10 and 3 ?",
+                "text": "Is any department0 number0 section scheduled between time1 and time0 ?",
                 "variables": {
                     "department0": "BIOSTAT",
                     "number0": "995",
-                    "time0": "5:00",
-                    "time1": "9:00"
+                    "time0": "10:00",
+                    "time1": "3:00"
                 }
             },
             {
@@ -25113,11 +25113,11 @@
             },
             {
                 "question-split": "exclude",
-                "text": "For section in department0 number0 will time1 - 3:00 P.M. have offerings ?",
+                "text": "For section in department0 number0 will time1 - time0 have offerings ?",
                 "variables": {
                     "department0": "BIOMEDE",
                     "number0": "628",
-                    "time0": "4:00",
+                    "time0": "3:00",
                     "time1": "8:00"
                 }
             },

--- a/data/advising.json
+++ b/data/advising.json
@@ -9680,7 +9680,7 @@
             },
             {
                 "question-split": "train",
-                "text": "For the class about topic0s , what is the course number ?",
+                "text": "For the class about topic0 , what is the course number ?",
                 "variables": {
                     "topic0": "Creative Writing-Poetry"
                 }
@@ -9722,7 +9722,7 @@
             },
             {
                 "question-split": "test",
-                "text": "What 's the number of the course on topic0s ?",
+                "text": "What 's the number of the course on topic0 ?",
                 "variables": {
                     "topic0": "Mentorship- Multidisciplinary Design"
                 }
@@ -9743,7 +9743,7 @@
             },
             {
                 "question-split": "train",
-                "text": "What is the number of the course for topic0s ?",
+                "text": "What is the number of the course for topic0 ?",
                 "variables": {
                     "topic0": "Trademarks and Unfair Comp"
                 }
@@ -27376,7 +27376,7 @@
             },
             {
                 "question-split": "test",
-                "text": "Are there semester0s when department0 number0 has been offered ?",
+                "text": "Are there semester0 -s when department0 number0 has been offered ?",
                 "variables": {
                     "department0": "ARCH",
                     "number0": "589",
@@ -27430,7 +27430,7 @@
             },
             {
                 "question-split": "train",
-                "text": "Have there been any semester0s that department0 number0 has been offered ?",
+                "text": "Have there been any semester0 -s that department0 number0 has been offered ?",
                 "variables": {
                     "department0": "ENGR",
                     "number0": "599",

--- a/data/restaurants.json
+++ b/data/restaurants.json
@@ -621,7 +621,7 @@
         "sentences": [
             {
                 "question-split": "9",
-                "text": "what are some good restaurants on city_name0 rd in city_name0 ?",
+                "text": "what are some good restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -629,7 +629,7 @@
             },
             {
                 "question-split": "3",
-                "text": "give me some good restaurants on city_name0 rd in city_name0 ?",
+                "text": "give me some good restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -637,7 +637,7 @@
             },
             {
                 "question-split": "7",
-                "text": "give me a good restaurant on city_name0 rd in city_name0 ?",
+                "text": "give me a good restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -645,7 +645,7 @@
             },
             {
                 "question-split": "6",
-                "text": "what is a good restaurant on city_name0 rd in city_name0 ?",
+                "text": "what is a good restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -653,7 +653,7 @@
             },
             {
                 "question-split": "9",
-                "text": "what are some good restaurants on city_name0 rd in city_name0 ?",
+                "text": "what are some good restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -661,7 +661,7 @@
             },
             {
                 "question-split": "4",
-                "text": "give me some good restaurants on city_name0 rd in city_name0 ?",
+                "text": "give me some good restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -669,7 +669,7 @@
             },
             {
                 "question-split": "1",
-                "text": "give me a good restaurant on city_name0 rd in city_name0 ?",
+                "text": "give me a good restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -677,7 +677,7 @@
             },
             {
                 "question-split": "5",
-                "text": "what is a good restaurant on city_name0 rd in city_name0 ?",
+                "text": "what is a good restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -685,7 +685,7 @@
             },
             {
                 "question-split": "4",
-                "text": "what are some good restaurants on city_name0 rd in city_name0 ?",
+                "text": "what are some good restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -693,7 +693,7 @@
             },
             {
                 "question-split": "9",
-                "text": "give me some good restaurants on city_name0 rd in city_name0 ?",
+                "text": "give me some good restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -701,7 +701,7 @@
             },
             {
                 "question-split": "0",
-                "text": "give me a good restaurant on city_name0 rd in city_name0 ?",
+                "text": "give me a good restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -709,7 +709,7 @@
             },
             {
                 "question-split": "8",
-                "text": "what is a good restaurant on city_name0 rd in city_name0 ?",
+                "text": "what is a good restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -1299,7 +1299,7 @@
             },
             {
                 "question-split": "3",
-                "text": "where are some good arabics on street_name0 in city_name0 ?",
+                "text": "where are some good food_type0 -s on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "san francisco",
                     "food_type0": "arabic",
@@ -1479,7 +1479,7 @@
             },
             {
                 "question-split": "2",
-                "text": "give me some good arabics on street_name0 in city_name0 ?",
+                "text": "give me some good food_type0 -s on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "san francisco",
                     "food_type0": "arabic",
@@ -1497,7 +1497,7 @@
             },
             {
                 "question-split": "1",
-                "text": "where are some good arabics on street_name0 in city_name0 ?",
+                "text": "where are some good food_type0 -s on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "san francisco",
                     "food_type0": "arabic",
@@ -1677,7 +1677,7 @@
             },
             {
                 "question-split": "8",
-                "text": "give me some good arabics on street_name0 in city_name0 ?",
+                "text": "give me some good food_type0 -s on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "san francisco",
                     "food_type0": "arabic",
@@ -1695,7 +1695,7 @@
             },
             {
                 "question-split": "9",
-                "text": "where are some good arabics on street_name0 in city_name0 ?",
+                "text": "where are some good food_type0 -s on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "san francisco",
                     "food_type0": "arabic",
@@ -1875,7 +1875,7 @@
             },
             {
                 "question-split": "3",
-                "text": "give me some good arabics on street_name0 in city_name0 ?",
+                "text": "give me some good food_type0 -s on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "san francisco",
                     "food_type0": "arabic",
@@ -2064,7 +2064,7 @@
         "sentences": [
             {
                 "question-split": "1",
-                "text": "give me some restaurants on city_name0 rd in city_name0 ?",
+                "text": "give me some restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2072,7 +2072,7 @@
             },
             {
                 "question-split": "3",
-                "text": "give me a restaurant on city_name0 rd in city_name0 ?",
+                "text": "give me a restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2080,7 +2080,7 @@
             },
             {
                 "question-split": "0",
-                "text": "where can we find a restaurant on city_name0 rd in city_name0 ?",
+                "text": "where can we find a restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2088,7 +2088,7 @@
             },
             {
                 "question-split": "8",
-                "text": "where can we find some restaurants on city_name0 rd in city_name0 ?",
+                "text": "where can we find some restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2096,7 +2096,7 @@
             },
             {
                 "question-split": "7",
-                "text": "give me some restaurants on city_name0 rd in city_name0 ?",
+                "text": "give me some restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2104,7 +2104,7 @@
             },
             {
                 "question-split": "4",
-                "text": "give me a restaurant on city_name0 rd in city_name0 ?",
+                "text": "give me a restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2112,7 +2112,7 @@
             },
             {
                 "question-split": "4",
-                "text": "where can we find a restaurant on city_name0 rd in city_name0 ?",
+                "text": "where can we find a restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2120,7 +2120,7 @@
             },
             {
                 "question-split": "8",
-                "text": "where can we find some restaurants on city_name0 rd in city_name0 ?",
+                "text": "where can we find some restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2128,7 +2128,7 @@
             },
             {
                 "question-split": "2",
-                "text": "give me some restaurants on city_name0 rd in city_name0 ?",
+                "text": "give me some restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2136,7 +2136,7 @@
             },
             {
                 "question-split": "1",
-                "text": "give me a restaurant on city_name0 rd in city_name0 ?",
+                "text": "give me a restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2144,7 +2144,7 @@
             },
             {
                 "question-split": "4",
-                "text": "where can we find a restaurant on city_name0 rd in city_name0 ?",
+                "text": "where can we find a restaurant on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2152,7 +2152,7 @@
             },
             {
                 "question-split": "0",
-                "text": "where can we find some restaurants on city_name0 rd in city_name0 ?",
+                "text": "where can we find some restaurants on street_name0 in city_name0 ?",
                 "variables": {
                     "city_name0": "bethel island",
                     "street_name0": "bethel island rd"
@@ -2942,7 +2942,7 @@
             },
             {
                 "question-split": "9",
-                "text": "where are some good arabics in city_name0 ?",
+                "text": "where are some good food_type0 -s in city_name0 ?",
                 "variables": {
                     "city_name0": "mountain view",
                     "food_type0": "arabic"
@@ -3022,7 +3022,7 @@
             },
             {
                 "question-split": "7",
-                "text": "give me some good arabics in city_name0 ?",
+                "text": "give me some good food_type0 -s in city_name0 ?",
                 "variables": {
                     "city_name0": "mountain view",
                     "food_type0": "arabic"
@@ -3126,7 +3126,7 @@
             },
             {
                 "question-split": "5",
-                "text": "where are some good arabics in city_name0 ?",
+                "text": "where are some good food_type0 -s in city_name0 ?",
                 "variables": {
                     "city_name0": "mountain view",
                     "food_type0": "arabic"
@@ -3206,7 +3206,7 @@
             },
             {
                 "question-split": "2",
-                "text": "give me some good arabics in city_name0 ?",
+                "text": "give me some good food_type0 -s in city_name0 ?",
                 "variables": {
                     "city_name0": "mountain view",
                     "food_type0": "arabic"
@@ -3310,7 +3310,7 @@
             },
             {
                 "question-split": "2",
-                "text": "where are some good arabics in city_name0 ?",
+                "text": "where are some good food_type0 -s in city_name0 ?",
                 "variables": {
                     "city_name0": "mountain view",
                     "food_type0": "arabic"
@@ -3390,7 +3390,7 @@
             },
             {
                 "question-split": "3",
-                "text": "give me some good arabics in city_name0 ?",
+                "text": "give me some good food_type0 -s in city_name0 ?",
                 "variables": {
                     "city_name0": "mountain view",
                     "food_type0": "arabic"

--- a/data/scholar.json
+++ b/data/scholar.json
@@ -129,8 +129,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "Philipp Haberstock",
-                    "authorname1": "Ludwig Nastansky",
-                    "misc0": "2"
+                    "authorname1": "Ludwig Nastansky"
                 }
             },
             {
@@ -138,8 +137,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "X Jiang",
-                    "authorname1": "Frantzen",
-                    "misc0": "2"
+                    "authorname1": "Frantzen"
                 }
             },
             {
@@ -147,8 +145,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "X Jiang",
-                    "authorname1": "Frantzen",
-                    "misc0": "2"
+                    "authorname1": "Frantzen"
                 }
             },
             {
@@ -156,8 +153,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "Peter Mertens",
-                    "authorname1": "Dina Barbian",
-                    "misc0": "2"
+                    "authorname1": "Dina Barbian"
                 }
             },
             {
@@ -165,8 +161,7 @@
                 "question-split": "test",
                 "variables": {
                     "authorname0": "Peter Mertens",
-                    "authorname1": "Dina Barbian",
-                    "misc0": "2"
+                    "authorname1": "Dina Barbian"
                 }
             },
             {
@@ -174,14 +169,13 @@
                 "question-split": "test",
                 "variables": {
                     "authorname0": "Peter Mertens",
-                    "authorname1": "Dina Barbian",
-                    "misc0": "2"
+                    "authorname1": "Dina Barbian"
                 }
             }
         ],
         "sql": [
             "SELECT DISTINCT WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , AUTHOR AS AUTHORalias1 , WRITES AS WRITESalias0 , WRITES AS WRITESalias1 WHERE AUTHORalias0.AUTHORNAME = \"authorname0\" AND AUTHORalias1.AUTHORNAME = \"authorname1\" AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias1.AUTHORID = AUTHORalias1.AUTHORID AND WRITESalias1.PAPERID = WRITESalias0.PAPERID ;",
-            "SELECT DISTINCT WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID GROUP BY WRITESalias0.PAPERID HAVING COUNT( DISTINCT WRITESalias0.AUTHORID ) = misc0 ;"
+            "SELECT DISTINCT WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID GROUP BY WRITESalias0.PAPERID HAVING COUNT( DISTINCT WRITESalias0.AUTHORID ) = 2 ;"
         ],
         "variables": [
             {
@@ -3157,7 +3151,7 @@
                 }
             },
             {
-                "text": "I want the papers on keyphrase0 by authorname0",
+                "text": "I want the papers on keyphrasename0 by authorname0",
                 "question-split": "train",
                 "variables": {
                     "authorname0": "philipp koehn",
@@ -3683,21 +3677,19 @@
                 "text": "journal articles by authorname0",
                 "question-split": "train",
                 "variables": {
-                    "authorname0": "lorenzo bruzzone",
-                    "journalid0": "0"
+                    "authorname0": "lorenzo bruzzone"
                 }
             },
             {
                 "text": "Journal Papers by authorname0",
                 "question-split": "train",
                 "variables": {
-                    "authorname0": "mohammad rastegari",
-                    "journalid0": "0"
+                    "authorname0": "mohammad rastegari"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , PAPER AS PAPERalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME = \"authorname0\" AND PAPERalias0.JOURNALID >= journalid0 AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID ;"
+            "SELECT DISTINCT PAPERalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , PAPER AS PAPERalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME = \"authorname0\" AND PAPERalias0.JOURNALID >= 0 AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID ;"
         ],
         "variables": [
             {
@@ -3705,12 +3697,6 @@
                 "location": "unk",
                 "name": "authorname0",
                 "type": "authorname"
-            },
-            {
-                "example": "0",
-                "location": "unk",
-                "name": "journalid0",
-                "type": "journalid"
             }
         ]
     },
@@ -3852,13 +3838,12 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver in the Decision Feedback",
-                    "year0": "2016",
-                    "misc0": "1"
+                    "year0": "2016"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME = \"keyphrasename0\" AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID AND PAPERalias0.YEAR = year0 GROUP BY PAPERalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > misc0 ;"
+            "SELECT DISTINCT PAPERalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME = \"keyphrasename0\" AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID AND PAPERalias0.YEAR = year0 GROUP BY PAPERalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > 1 ;"
         ],
         "variables": [
             {
@@ -3872,12 +3857,6 @@
                 "location": "unk",
                 "name": "year0",
                 "type": "year"
-            },
-            {
-                "example": "1",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -4280,7 +4259,7 @@
                 "question-split": "dev",
                 "variables": {
                     "year0": "2000",
-                    "benuename0": "SIGMOD"
+                    "venuename0": "SIGMOD"
                 }
             },
             {
@@ -4885,8 +4864,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Neural",
-                    "keyphrasename1": "Relation Extraction",
-                    "misc0": "2"
+                    "keyphrasename1": "Relation Extraction"
                 }
             },
             {
@@ -4894,8 +4872,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4903,8 +4880,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4912,8 +4888,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4921,8 +4896,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4930,8 +4904,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Convolution",
-                    "keyphrasename1": "Combinatoric",
-                    "misc0": "1"
+                    "keyphrasename1": "Combinatoric"
                 }
             },
             {
@@ -4939,8 +4912,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4948,8 +4920,7 @@
                 "question-split": "dev",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4957,8 +4928,7 @@
                 "question-split": "dev",
                 "variables": {
                     "keyphrasename0": "Decision Feedback",
-                    "keyphrasename1": "Multiuser Receiver",
-                    "misc0": "1"
+                    "keyphrasename1": "Multiuser Receiver"
                 }
             },
             {
@@ -4966,8 +4936,7 @@
                 "question-split": "test",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -4975,15 +4944,14 @@
                 "question-split": "test",
                 "variables": {
                     "keyphrasename0": "multiuser receiver",
-                    "keyphrasename1": "decision feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "decision feedback"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERKEYPHRASEalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) GROUP BY PAPERKEYPHRASEalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASEID ) = misc0 ;",
-            "SELECT DISTINCT PAPERalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > misc0 ;",
-            "SELECT DISTINCT PAPERalias0.PAPERID , PAPERalias0.YEAR FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > misc0 ;"
+            "SELECT DISTINCT PAPERKEYPHRASEalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) GROUP BY PAPERKEYPHRASEalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASEID ) = 1 ;",
+            "SELECT DISTINCT PAPERalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > 1 ;",
+            "SELECT DISTINCT PAPERalias0.PAPERID , PAPERalias0.YEAR FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERalias0.PAPERID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > 1 ;"
         ],
         "variables": [
             {
@@ -4997,12 +4965,6 @@
                 "location": "unk",
                 "name": "keyphrasename1",
                 "type": "keyphrasename"
-            },
-            {
-                "example": "2",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -5334,13 +5296,12 @@
                 "text": "journal papers for keyphrasename0",
                 "question-split": "train",
                 "variables": {
-                    "keyphrasename0": "instance segmentation",
-                    "journalid0": "0"
+                    "keyphrasename0": "instance segmentation"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME = \"keyphrasename0\" AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.JOURNALID >= journalid0 AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID ;"
+            "SELECT DISTINCT PAPERalias0.PAPERID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME = \"keyphrasename0\" AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.JOURNALID >= 0 AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID ;"
         ],
         "variables": [
             {
@@ -5348,12 +5309,6 @@
                 "location": "unk",
                 "name": "keyphrasename0",
                 "type": "keyphrasename"
-            },
-            {
-                "example": "0",
-                "location": "unk",
-                "name": "journalid0",
-                "type": "journalid"
             }
         ]
     },
@@ -5961,8 +5916,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "Dan Suciu",
-                    "authorname1": "Magdalena Balazinska",
-                    "misc0": "2"
+                    "authorname1": "Magdalena Balazinska"
                 }
             },
             {
@@ -5970,8 +5924,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "Dan Suciu",
-                    "authorname1": "Magdalena Balazinska",
-                    "misc0": "2"
+                    "authorname1": "Magdalena Balazinska"
                 }
             },
             {
@@ -5979,8 +5932,7 @@
                 "question-split": "test",
                 "variables": {
                     "authorname0": "X Jiang",
-                    "authorname1": "Frantzen",
-                    "misc0": "2"
+                    "authorname1": "Frantzen"
                 }
             },
             {
@@ -5988,14 +5940,13 @@
                 "question-split": "test",
                 "variables": {
                     "authorname0": "Dan Suciu",
-                    "authorname1": "Magdalena Balazinska",
-                    "misc0": "2"
+                    "authorname1": "Magdalena Balazinska"
                 }
             }
         ],
         "sql": [
             "SELECT DISTINCT COUNT( 1 ) FROM AUTHOR AS AUTHORalias0 , AUTHOR AS AUTHORalias1 , WRITES AS WRITESalias0 , WRITES AS WRITESalias1 WHERE AUTHORalias0.AUTHORNAME = \"authorname0\" AND AUTHORalias1.AUTHORNAME = \"authorname1\" AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias1.AUTHORID = AUTHORalias1.AUTHORID AND WRITESalias1.PAPERID = WRITESalias0.PAPERID ;",
-            "SELECT DISTINCT COUNT( DERIVED_TABLEalias0.PAPERID ) FROM ( SELECT WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID GROUP BY WRITES.PAPERID HAVING COUNT( DISTINCT WRITES.AUTHORID ) = misc0 ) AS DERIVED_TABLEalias0 ;"
+            "SELECT DISTINCT COUNT( DERIVED_TABLEalias0.PAPERID ) FROM ( SELECT WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID GROUP BY WRITES.PAPERID HAVING COUNT( DISTINCT WRITES.AUTHORID ) = 2 ) AS DERIVED_TABLEalias0 ;"
         ],
         "variables": [
             {
@@ -6390,8 +6341,7 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "Akihito Kotera",
-                    "authorname1": "Masatsugu Kidode",
-                    "misc0": "2"
+                    "authorname1": "Masatsugu Kidode"
                 }
             },
             {
@@ -6399,13 +6349,12 @@
                 "question-split": "dev",
                 "variables": {
                     "authorname0": "Luke S Zettlemoyer",
-                    "authorname1": "Mirella Lapata",
-                    "misc0": "2"
+                    "authorname1": "Mirella Lapata"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERKEYPHRASEalias0.KEYPHRASEID FROM AUTHOR AS AUTHORalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERKEYPHRASEalias0.KEYPHRASEID HAVING COUNT( DISTINCT WRITESalias0.AUTHORID ) = misc0 ;"
+            "SELECT DISTINCT PAPERKEYPHRASEalias0.KEYPHRASEID FROM AUTHOR AS AUTHORalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERKEYPHRASEalias0.KEYPHRASEID HAVING COUNT( DISTINCT WRITESalias0.AUTHORID ) = 2 ;"
         ],
         "variables": [
             {
@@ -6419,12 +6368,6 @@
                 "location": "unk",
                 "name": "authorname1",
                 "type": "authorname"
-            },
-            {
-                "example": "2",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -6548,7 +6491,7 @@
             }
         ],
         "sql": [
-            "SELECT DISTINCT COUNT( PAPERalias0.PAPERID ) FROM AUTHOR AS AUTHORalias0 , PAPER AS PAPERalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME = \"authorname0\" AND PAPERalias0.YEAR >= YEAR(CURDATE()) - misc0 AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID ;"
+            "SELECT DISTINCT COUNT( PAPERalias0.PAPERID ) FROM AUTHOR AS AUTHORalias0 , PAPER AS PAPERalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME = \"authorname0\" AND PAPERalias0.YEAR == YEAR(CURDATE()) - misc0 AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID ;"
         ],
         "variables": [
             {
@@ -6840,8 +6783,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -6849,8 +6791,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -6858,8 +6799,7 @@
                 "question-split": "dev",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -6867,8 +6807,7 @@
                 "question-split": "test",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -6876,13 +6815,12 @@
                 "question-split": "test",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT WRITESalias0.AUTHORID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 , WRITES AS WRITESalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.AUTHORID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > misc0 ;"
+            "SELECT DISTINCT WRITESalias0.AUTHORID FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 , WRITES AS WRITESalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.AUTHORID HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > 1 ;"
         ],
         "variables": [
             {
@@ -6896,12 +6834,6 @@
                 "location": "unk",
                 "name": "keyphrasename1",
                 "type": "keyphrasename"
-            },
-            {
-                "example": "1",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -7741,8 +7673,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Decision Feedback",
-                    "keyphrasename1": "Multiuser Receiver",
-                    "misc0": "1"
+                    "keyphrasename1": "Multiuser Receiver"
                 }
             },
             {
@@ -7750,8 +7681,7 @@
                 "question-split": "train",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -7759,8 +7689,7 @@
                 "question-split": "test",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             },
             {
@@ -7768,13 +7697,12 @@
                 "question-split": "test",
                 "variables": {
                     "keyphrasename0": "Multiuser Receiver",
-                    "keyphrasename1": "Decision Feedback",
-                    "misc0": "1"
+                    "keyphrasename1": "Decision Feedback"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERalias0.PAPERID , PAPERalias0.YEAR FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERalias0.PAPERID , PAPERalias0.YEAR HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > misc0 ORDER BY PAPERalias0.YEAR ASC ;"
+            "SELECT DISTINCT PAPERalias0.PAPERID , PAPERalias0.YEAR FROM KEYPHRASE AS KEYPHRASEalias0 , PAPER AS PAPERalias0 , PAPERKEYPHRASE AS PAPERKEYPHRASEalias0 WHERE KEYPHRASEalias0.KEYPHRASENAME IN ( \"keyphrasename0\" , \"keyphrasename1\" ) AND PAPERKEYPHRASEalias0.KEYPHRASEID = KEYPHRASEalias0.KEYPHRASEID AND PAPERalias0.PAPERID = PAPERKEYPHRASEalias0.PAPERID GROUP BY PAPERalias0.PAPERID , PAPERalias0.YEAR HAVING COUNT( DISTINCT KEYPHRASEalias0.KEYPHRASENAME ) > 1 ORDER BY PAPERalias0.YEAR ASC ;"
         ],
         "variables": [
             {
@@ -7788,12 +7716,6 @@
                 "location": "unk",
                 "name": "keyphrasename1",
                 "type": "keyphrasename"
-            },
-            {
-                "example": "1",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -9056,13 +8978,12 @@
                 "question-split": "train",
                 "variables": {
                     "authorname0": "Nigam H. Shah",
-                    "authorname1": "Srinivasan Iyer",
-                    "misc0": "2"
+                    "authorname1": "Srinivasan Iyer"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT PAPERalias0.YEAR , WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , PAPER AS PAPERalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.PAPERID HAVING COUNT( DISTINCT WRITESalias0.AUTHORID ) = misc0 ORDER BY PAPERalias0.YEAR DESC ;"
+            "SELECT DISTINCT PAPERalias0.YEAR , WRITESalias0.PAPERID FROM AUTHOR AS AUTHORalias0 , PAPER AS PAPERalias0 , WRITES AS WRITESalias0 WHERE AUTHORalias0.AUTHORNAME IN ( \"authorname0\" , \"authorname1\" ) AND WRITESalias0.AUTHORID = AUTHORalias0.AUTHORID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.PAPERID HAVING COUNT( DISTINCT WRITESalias0.AUTHORID ) = 2 ORDER BY PAPERalias0.YEAR DESC ;"
         ],
         "variables": [
             {
@@ -9076,12 +8997,6 @@
                 "location": "unk",
                 "name": "authorname1",
                 "type": "authorname"
-            },
-            {
-                "example": "2",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -9321,8 +9236,7 @@
                 "question-split": "dev",
                 "variables": {
                     "venuename0": "ICML",
-                    "venuename1": "ACL",
-                    "misc0": "2"
+                    "venuename1": "ACL"
                 }
             },
             {
@@ -9330,13 +9244,12 @@
                 "question-split": "test",
                 "variables": {
                     "venuename0": "ICML",
-                    "venuename1": "Science ( New York , N.Y. )",
-                    "misc0": "2"
+                    "venuename1": "Science ( New York , N.Y. )"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT WRITESalias0.AUTHORID FROM PAPER AS PAPERalias0 , VENUE AS VENUEalias0 , WRITES AS WRITESalias0 WHERE VENUEalias0.VENUEID = PAPERalias0.VENUEID AND VENUEalias0.VENUENAME IN ( \"venuename0\" , \"venuename1\" ) AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.AUTHORID HAVING COUNT( DISTINCT VENUEalias0.VENUEID ) = misc0 ;"
+            "SELECT DISTINCT WRITESalias0.AUTHORID FROM PAPER AS PAPERalias0 , VENUE AS VENUEalias0 , WRITES AS WRITESalias0 WHERE VENUEalias0.VENUEID = PAPERalias0.VENUEID AND VENUEalias0.VENUENAME IN ( \"venuename0\" , \"venuename1\" ) AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.AUTHORID HAVING COUNT( DISTINCT VENUEalias0.VENUEID ) = 2 ;"
         ],
         "variables": [
             {
@@ -9350,12 +9263,6 @@
                 "location": "unk",
                 "name": "venuename1",
                 "type": "venuename"
-            },
-            {
-                "example": "2",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },
@@ -9523,13 +9430,12 @@
                 "question-split": "test",
                 "variables": {
                     "venuename0": "ICASSP",
-                    "venuename1": "ICSLP",
-                    "misc0": "2"
+                    "venuename1": "ICSLP"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT COUNT( DISTINCT CITEalias0.CITINGPAPERID ) , WRITESalias0.AUTHORID FROM CITE AS CITEalias0 , PAPER AS PAPERalias0 , VENUE AS VENUEalias0 , WRITES AS WRITESalias0 WHERE VENUEalias0.VENUEID = PAPERalias0.VENUEID AND VENUEalias0.VENUENAME IN ( \"venuename0\" , \"venuename1\" ) AND WRITESalias0.PAPERID = CITEalias0.CITEDPAPERID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.AUTHORID HAVING COUNT( DISTINCT VENUEalias0.VENUEID ) = misc0 ORDER BY COUNT( DISTINCT CITEalias0.CITINGPAPERID ) DESC ;"
+            "SELECT DISTINCT COUNT( DISTINCT CITEalias0.CITINGPAPERID ) , WRITESalias0.AUTHORID FROM CITE AS CITEalias0 , PAPER AS PAPERalias0 , VENUE AS VENUEalias0 , WRITES AS WRITESalias0 WHERE VENUEalias0.VENUEID = PAPERalias0.VENUEID AND VENUEalias0.VENUENAME IN ( \"venuename0\" , \"venuename1\" ) AND WRITESalias0.PAPERID = CITEalias0.CITEDPAPERID AND WRITESalias0.PAPERID = PAPERalias0.PAPERID GROUP BY WRITESalias0.AUTHORID HAVING COUNT( DISTINCT VENUEalias0.VENUEID ) = 2 ORDER BY COUNT( DISTINCT CITEalias0.CITINGPAPERID ) DESC ;"
         ],
         "variables": [
             {
@@ -9543,12 +9449,6 @@
                 "location": "unk",
                 "name": "venuename1",
                 "type": "venuename"
-            },
-            {
-                "example": "2",
-                "location": "unk",
-                "name": "misc0",
-                "type": "misc"
             }
         ]
     },

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -28,6 +28,27 @@ If you use this code, please cite our ACL paper:
 }
 ```
 
+## Note on evaluation bug
+
+After publication we were made aware (via GitHub issues) of a bug in the baseline model.
+The template generation did not correctly consider variables that are implicitly defined by the text (the intention was that multiple templates would be created for such cases).
+This meant that the evaluation, which only checked if the right template was chosen and the right tags were assigned, was incorrect.
+We fixed the bug and changed the evaluation to compare the filled in query.
+
+The table below shows the old and new results.
+None of the non-oracle results shifted substantially.
+There are some large drops for the oracle entities setting (ATIS and Scholar), but the results do not change the findings of the paper.
+The reason some values improved is that when filling in the query with slots tags that are inconsistent with the chosen template are ignored (and so cases that were previously wrong are now right).
+
+                    | Advising  | ATIS | GeoQuery | Scholar | Restaurants | Academic | IMDB | Yelp
+------------------- | --------- | ---- | -------- | ------- | ----------- | -------- | ---- | ----
+Old Baseline        |        80 |   46 |       57 |      52 |          95 |        0 |    0 |    1
+New Baseline        |        83 |   45 |       57 |      54 |          92 |        1 |    1 |    0
+Old Oracle Entities |        89 |   56 |       56 |      66 |          95 |        0 |    7 |    8
+New Oracle Entities |        87 |   49 |       59 |      59 |          92 |        1 |    2 |    3
+Old Oracle All      |       100 |   69 |       78 |      84 |         100 |       11 |   47 |   25
+New Oracle All      |       100 |   66 |       78 |      82 |         100 |       11 |   47 |   25
+
 ## Requirements
 
 - Python 3

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -59,7 +59,7 @@ To handle that, use the `--split` flag, with an argument indicating the split nu
 The parameters were varied slightly for each dataset (any not listed here were set to the default).
 The following flags were set for evaluation on all datasets:
 
-`--eval_freq 1000000 --log_freq 1000000 --max_bad_iters -1 --do_test_eval`
+`--eval-freq 1000000 --log-freq 1000000 --max-bad-iters -1 --do-test-eval`
 
 Dataset                           | Parameter            | Value
 --------------------------------- | -------------------- | ----------

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -40,7 +40,7 @@ None of the non-oracle results shifted substantially.
 There are some large drops for the oracle entities setting (ATIS and Scholar), but the results do not change the findings of the paper.
 The reason some values improved is that when filling in the query with slots tags that are inconsistent with the chosen template are ignored (and so cases that were previously wrong are now right).
 
-                    | Advising  | ATIS | GeoQuery | Scholar | Restaurants | Academic | IMDB | Yelp
+System              | Advising  | ATIS | GeoQuery | Scholar | Restaurants | Academic | IMDB | Yelp
 ------------------- | --------- | ---- | -------- | ------- | ----------- | -------- | ---- | ----
 Old Baseline        |        80 |   46 |       57 |      52 |          95 |        0 |    0 |    1
 New Baseline        |        83 |   45 |       57 |      54 |          92 |        1 |    1 |    0

--- a/systems/baseline-template/text2sql-template-baseline.py
+++ b/systems/baseline-template/text2sql-template-baseline.py
@@ -52,12 +52,14 @@ import dynet as dy # Loaded late to avoid memory allocation when we just want he
 def insert_variables(sql, sql_variables, sent, sent_variables):
     tokens = []
     tags = []
+    seen_sent_variables = set()
     for token in sent.strip().split():
         if (token not in sent_variables) or args.no_vars:
             tokens.append(token)
             tags.append("O")
         else:
             assert len(sent_variables[token]) > 0
+            seen_sent_variables.add(token)
             for word in sent_variables[token].split():
                 tokens.append(word)
                 tags.append(token)
@@ -81,18 +83,33 @@ def insert_variables(sql, sql_variables, sent, sent_variables):
             sql_tokens.append(token)
 
     template = []
+    complete = []
     for token in sql_tokens:
-        if (token not in sent_variables) and (token not in sql_variables):
+        # Do the template
+        if token in seen_sent_variables:
+            # The token is a variable name that will be copied from the sentence
             template.append(token)
-        elif token in sent_variables:
-            if sent_variables[token] == '':
-                template.append(sql_variables[token])
-            else:
-                template.append(token)
-        elif token in sql_variables:
+        elif (token not in sent_variables) and (token not in sql_variables):
+            # The token is an SQL keyword
+            template.append(token)
+        elif token in sent_variables and sent_variables[token] != '':
+            # The token is a variable whose value is unique to this questions,
+            # but is not explicitly given
+            template.append(sent_variables[token])
+        else:
+            # The token is a variable whose value is not unique to this
+            # question and not explicitly given
             template.append(sql_variables[token])
 
-    return (tokens, tags, ' '.join(template))
+        # Do the complete case
+        if token in sent_variables and sent_variables[token] != '':
+            complete.append(sent_variables[token])
+        elif token in sql_variables:
+            complete.append(sql_variables[token])
+        else:
+            complete.append(token)
+
+    return (tokens, tags, ' '.join(template), ' '.join(complete))
 
 def get_tagged_data_for_query(data):
     dataset = data['query-split']
@@ -162,7 +179,7 @@ def build_vocab(sentences):
     words = {"<UNK>"}
     tag_set = set()
     template_set = set()
-    for tokens, tags, template in train:
+    for tokens, tags, template, complete in train:
         template_set.add(template)
         for tag in tags:
             tag_set.add(tag)
@@ -276,36 +293,60 @@ def build_tagging_graph(words, tags, template, builders, train=True):
 
     return pred_tags, pred_template, errs
 
+def insert_tagged_tokens(tokens, tags, template):
+    to_insert = {}
+    cur = (None, [])
+    for token, tag in zip(tokens, tags):
+        if tag != cur[0]:
+            if cur[0] is not None:
+                value = ' '.join(cur[1])
+                to_insert[cur[0]] = value
+            if tag == 'O':
+                cur = (None, [])
+            else:
+                cur = (tag, [token])
+        else:
+            cur[1].append(token)
+    if cur[0] is not None:
+        value = ' '.join(cur[1])
+        to_insert[cur[0]] = value
+
+    modified = []
+    for token in template.split():
+        modified.append(to_insert.get(token, token))
+
+    return ' '.join(modified)
+
 def run_eval(data, builders, iteration, step):
     if len(data) == 0:
         print("No data for eval")
         return -1
-    good = 0.0
-    total = 0.0
-    complete_good = 0.0
-    templates_good = 0.0
+    correct_tags = 0.0
+    total_tags = 0.0
+    complete_match = 0.0
+    templates_match = 0.0
     oracle = 0.0
-    for tokens, tags, template in data:
+    for tokens, tags, template, complete in data:
         word_ids = [vocab_words.w2i.get(word, UNK) for word in tokens]
         tag_ids = [0 for tag in tags]
         pred_tags, pred_template, _ = build_tagging_graph(word_ids, tag_ids, 0, builders, False)
         gold_tags = tags
-        perfect = True
         for gold, pred in zip(gold_tags, pred_tags):
-            total += 1
-            if gold == pred: good += 1
-            else: perfect = False
+            total_tags += 1
+            if gold == pred: correct_tags += 1
+        pred_complete = insert_tagged_tokens(tokens, pred_tags, pred_template)
+        if pred_complete == complete:
+            complete_match += 1
         if pred_template == template:
-            templates_good += 1
-            if perfect:
-                complete_good += 1
+            templates_match += 1
         if template in vocab_templates.w2i:
             oracle += 1
-    tok_acc = good / total
-    complete_acc = complete_good / len(data)
-    template_acc = templates_good / len(data)
+
+    tok_acc = correct_tags / total_tags
+    complete_acc = complete_match / len(data)
+    template_acc = templates_match / len(data)
     oracle_acc = oracle / len(data)
-    print("Eval {}-{} Acc: {:>5} Template: {:>5} Complete: {:>5} Oracle: {:>5}".format(iteration, step, tok_acc, template_acc, complete_acc, oracle_acc))
+    print("Eval {}-{} Tag Acc: {:>5} Template: {:>5} Complete: {:>5} Oracle: {:>5}".format(iteration, step, tok_acc, template_acc, complete_acc, oracle_acc))
     return complete_acc
 
 tagged = 0
@@ -315,7 +356,7 @@ iters_since_best_updated = 0
 steps = 0
 for iteration in range(args.max_iters):
     random.shuffle(train)
-    for tokens, tags, template in train:
+    for tokens, tags, template, complete in train:
         steps += 1
 
         # Convert to indices

--- a/systems/baseline-template/text2sql-template-baseline.py
+++ b/systems/baseline-template/text2sql-template-baseline.py
@@ -18,30 +18,30 @@ parser = argparse.ArgumentParser(description='A simple template-based text-to-SQ
 
 # IO
 parser.add_argument('data', help='Data in json format', nargs='+')
-parser.add_argument('--unk_max', help='Maximum count to be considered an unknown word', type=int, default=0)
-parser.add_argument('--query_split', help='Use the query split rather than the question split', action='store_true')
-parser.add_argument('--no_vars', help='Run without filling in variables', action='store_true')
-parser.add_argument('--use_all_sql', help='Default is to use first SQL only, this makes multiple instances.', action='store_true')
-parser.add_argument('--do_test_eval', help='Do the final evaluation on the test set (rather than dev).', action='store_true')
+parser.add_argument('--unk-max', help='Maximum count to be considered an unknown word', type=int, default=0)
+parser.add_argument('--query-split', help='Use the query split rather than the question split', action='store_true')
+parser.add_argument('--no-vars', help='Run without filling in variables', action='store_true')
+parser.add_argument('--use-all-sql', help='Default is to use first SQL only, this makes multiple instances.', action='store_true')
+parser.add_argument('--do-test-eval', help='Do the final evaluation on the test set (rather than dev).', action='store_true')
 parser.add_argument('--split', help='Use this split in cross-validation.', type=int) # Used for small datasets: Academic, Restaurants, IMDB, Yelp
 
 # Model
 parser.add_argument('--mlp', help='Use a multi-layer perceptron', action='store_true')
-parser.add_argument('--dim_word', help='Dimensionality of word embeddings', type=int, default=128)
-parser.add_argument('--dim_hidden_lstm', help='Dimensionality of LSTM hidden vectors', type=int, default=64)
-parser.add_argument('--dim_hidden_mlp', help='Dimensionality of MLP hidden vectors', type=int, default=32)
-parser.add_argument('--dim_hidden_template', help='Dimensionality of MLP hidden vectors for the final template choice', type=int, default=64)
-parser.add_argument('--word_vectors', help='Pre-built word embeddings')
-parser.add_argument('--lstm_layers', help='Number of layers in the LSTM', type=int, default=2)
+parser.add_argument('--dim-word', help='Dimensionality of word embeddings', type=int, default=128)
+parser.add_argument('--dim-hidden-lstm', help='Dimensionality of LSTM hidden vectors', type=int, default=64)
+parser.add_argument('--dim-hidden-mlp', help='Dimensionality of MLP hidden vectors', type=int, default=32)
+parser.add_argument('--dim-hidden-template', help='Dimensionality of MLP hidden vectors for the final template choice', type=int, default=64)
+parser.add_argument('--word-vectors', help='Pre-built word embeddings')
+parser.add_argument('--lstm-layers', help='Number of layers in the LSTM', type=int, default=2)
 
 # Training
-parser.add_argument('--max_iters', help='Maximum number of training iterations', type=int, default=50)
-parser.add_argument('--max_bad_iters', help='Maximum number of consecutive training iterations without improvement', type=int, default=5)
-parser.add_argument('--log_freq', help='Number of examples to decode between logging', type=int, default=400)
-parser.add_argument('--eval_freq', help='Number of examples to decode between evaluation runs', type=int, default=800)
-parser.add_argument('--train_noise', help='Noise added to word embeddings as regularization', type=float, default=0.1)
-parser.add_argument('--lstm_dropout', help='Dropout for input and hidden elements of the LSTM', type=float, default=0.0)
-parser.add_argument('--learning_rate', help='Learning rate for optimiser', type=float, default="0.1")
+parser.add_argument('--max-iters', help='Maximum number of training iterations', type=int, default=50)
+parser.add_argument('--max-bad-iters', help='Maximum number of consecutive training iterations without improvement', type=int, default=5)
+parser.add_argument('--log-freq', help='Number of examples to decode between logging', type=int, default=400)
+parser.add_argument('--eval-freq', help='Number of examples to decode between evaluation runs', type=int, default=800)
+parser.add_argument('--train-noise', help='Noise added to word embeddings as regularization', type=float, default=0.1)
+parser.add_argument('--lstm-dropout', help='Dropout for input and hidden elements of the LSTM', type=float, default=0.0)
+parser.add_argument('--learning-rate', help='Learning rate for optimiser', type=float, default="0.1")
 
 args = parser.parse_args()
 


### PR DESCRIPTION
Fixing the issue raised in #7 that the templates used for evaluation were incorrect because they did not consider variables that did not explicitly appear in the question. The intention in this scenario was that multiple templates would be created in such cases, but the code did not do so correctly.

This update contains:

- Fixes to the template generation to correctly handle implicit variables
- Changes the evaluation to compare filled in queries
- Fixed some bugs in the data that were revealed in the process of fixing this bug

The last change impacts enough queries that a new data version number is needed.