### PR TITLE
Fix split definition for small datasets

### DIFF
--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -100,6 +100,40 @@ Academic, IMDB, Restaurants, Yelp | dim-word             | 64
 "                                 | lstm-layers          | 1
 "                                 | max-iters            | 3
 
+For example, this will run all of the experiments (assuming you are in this folder, have DyNet installed, and have four cores):
+
+```
+#!/bin/bash
+
+for i in `seq 1 8` ; do
+  to_wait=""
+
+  data="scholar"
+  ./text2sql-template-baseline.py ../../data/${data}.json --eval-freq 1000000 --log-freq 1000000 --max-bad-iters -1 --do-test-eval --max-iters 17 --lstm-layers 1 >out.${data}.${i}.txt 2>err.${data}.${i}.txt &
+  to_wait="${to_wait} $!"
+
+  data="geography"
+  ./text2sql-template-baseline.py ../../data/${data}.json --eval-freq 1000000 --log-freq 1000000 --max-bad-iters -1 --do-test-eval --max-iters 31 --dim-word 64 --dim-hidden-lstm 128 --dim-hidden-template 32  >out.${data}.${i}.txt 2>err.${data}.${i}.txt &
+  to_wait="${to_wait} $!"
+
+  data="advising"
+  ./text2sql-template-baseline.py ../../data/${data}.json --eval-freq 1000000 --log-freq 1000000 --max-bad-iters -1 --do-test-eval --max-iters 40 >out.${data}.${i}.txt 2>err.${data}.${i}.txt &
+  to_wait="${to_wait} $!"
+
+  data="atis"
+  ./text2sql-template-baseline.py ../../data/${data}.json --eval-freq 1000000 --log-freq 1000000 --max-bad-iters -1 --do-test-eval --max-iters 22 --learning-rate 0.05 >out.${data}.${i}.txt 2>err.${data}.${i}.txt &
+  to_wait="${to_wait} $!"
+
+  wait $to_wait
+done
+
+for data in academic yelp imdb restaurants ; do
+  for i in `seq 0 9` ; do
+    ./text2sql-template-baseline.py ../../data/${data}.json --split $i --dim-word 64 --dim-hidden-template 32 --train-noise 0.0 --lstm-layers 1 --max-iters 3 --eval-freq 1000000 --log-freq 1000000 --max-bad-iters -1 --do-test-eval >out.${data}.split${i}.txt 2>err.${data}.split${i}.txt
+  done
+done
+```
+
 ## License
 
 This code is a modified version of the example [tagger code](https://github.com/clab/dynet/blob/master/examples/tagger/bilstmtagger.py) from the DyNet repository.

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -28,7 +28,7 @@ If you use this code, please cite our ACL paper:
 }
 ```
 
-## Note on evaluation bug
+## Note on evaluation bugs
 
 After publication we were made aware (via GitHub issues) of two bugs in the baseline model.
 First, the template generation did not correctly consider variables that are implicitly defined by the text (the intention was that multiple templates would be created for such cases).
@@ -36,7 +36,7 @@ This meant that the evaluation, which only checked if the right template was cho
 We fixed the bug and changed the evaluation to compare the filled in query.
 Second, the splits were not correctly determined for the smaller datasets
 
-The table below shows the old and new results, with substantial shifts (5+) in bold.
+The table below shows the old and new results, with substantial shifts (5+) in bold with a star.
 None of the non-oracle results shifted substantially.
 There are some large drops for the oracle entities setting (ATIS and Scholar), but the results do not change the findings of the paper.
 The reason some values improved is that when filling in the query with slots tags that are inconsistent with the chosen template are ignored (and so cases that were previously wrong are now right).
@@ -46,7 +46,7 @@ System              | Advising  |   ATIS | GeoQuery | Scholar | Restaurants | Ac
 Old Baseline        |        80 |     46 |       57 |      52 |          95 |        0 |     0 |    1
 New Baseline        |        83 |     45 |       57 |      54 |          93 |        0 |     2 |    2
 Old Oracle Entities |        89 |     56 |       56 |      66 |          95 |        0 |     7 |    8
-New Oracle Entities |        87 | **49** |       59 |  **59** |          93 |        0 | **2** |    6
+New Oracle Entities |        87 | **\*49** |       59 |  **\*59** |          93 |        0 | **\*2** |    6
 Old Oracle All      |       100 |     69 |       78 |      84 |         100 |       11 |    47 |   25
 New Oracle All      |       100 |     66 |       78 |      82 |         100 |       11 |    47 |   25
 

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -41,14 +41,14 @@ None of the non-oracle results shifted substantially.
 There are some large drops for the oracle entities setting (ATIS and Scholar), but the results do not change the findings of the paper.
 The reason some values improved is that when filling in the query with slots tags that are inconsistent with the chosen template are ignored (and so cases that were previously wrong are now right).
 
-System              | Advising  | ATIS | GeoQuery | Scholar | Restaurants | Academic | IMDB | Yelp
-------------------- | --------- | ---- | -------- | ------- | ----------- | -------- | ---- | ----
-Old Baseline        |        80 |   46 |       57 |      52 |          95 |        0 |    0 |    1
-New Baseline        |        83 |   45 |       57 |      54 |          93 |        0 |    2 |    2
-Old Oracle Entities |        89 |   56 |       56 |      66 |          95 |        0 |    7 |    8
-New Oracle Entities |        87 | *49* |       59 |    *59* |          93 |        0 |  *2* |    6
-Old Oracle All      |       100 |   69 |       78 |      84 |         100 |       11 |   47 |   25
-New Oracle All      |       100 |   66 |       78 |      82 |         100 |       11 |   47 |   25
+System              | Advising  |   ATIS | GeoQuery | Scholar | Restaurants | Academic |  IMDB | Yelp
+------------------- | --------- | ------ | -------- | ------- | ----------- | -------- | ----- | ----
+Old Baseline        |        80 |     46 |       57 |      52 |          95 |        0 |     0 |    1
+New Baseline        |        83 |     45 |       57 |      54 |          93 |        0 |     2 |    2
+Old Oracle Entities |        89 |     56 |       56 |      66 |          95 |        0 |     7 |    8
+New Oracle Entities |        87 | **49** |       59 |  **59** |          93 |        0 | **2** |    6
+Old Oracle All      |       100 |     69 |       78 |      84 |         100 |       11 |    47 |   25
+New Oracle All      |       100 |     66 |       78 |      82 |         100 |       11 |    47 |   25
 
 ## Requirements
 

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -102,7 +102,7 @@ Academic, IMDB, Restaurants, Yelp | dim-word             | 64
 
 For example, this will run all of the experiments (assuming you are in this folder, have DyNet installed, and have four cores):
 
-```
+```bash
 #!/bin/bash
 
 for i in `seq 1 8` ; do

--- a/systems/baseline-template/README.md
+++ b/systems/baseline-template/README.md
@@ -30,12 +30,13 @@ If you use this code, please cite our ACL paper:
 
 ## Note on evaluation bug
 
-After publication we were made aware (via GitHub issues) of a bug in the baseline model.
-The template generation did not correctly consider variables that are implicitly defined by the text (the intention was that multiple templates would be created for such cases).
+After publication we were made aware (via GitHub issues) of two bugs in the baseline model.
+First, the template generation did not correctly consider variables that are implicitly defined by the text (the intention was that multiple templates would be created for such cases).
 This meant that the evaluation, which only checked if the right template was chosen and the right tags were assigned, was incorrect.
 We fixed the bug and changed the evaluation to compare the filled in query.
+Second, the splits were not correctly determined for the smaller datasets
 
-The table below shows the old and new results.
+The table below shows the old and new results, with substantial shifts (5+) in bold.
 None of the non-oracle results shifted substantially.
 There are some large drops for the oracle entities setting (ATIS and Scholar), but the results do not change the findings of the paper.
 The reason some values improved is that when filling in the query with slots tags that are inconsistent with the chosen template are ignored (and so cases that were previously wrong are now right).
@@ -43,9 +44,9 @@ The reason some values improved is that when filling in the query with slots tag
 System              | Advising  | ATIS | GeoQuery | Scholar | Restaurants | Academic | IMDB | Yelp
 ------------------- | --------- | ---- | -------- | ------- | ----------- | -------- | ---- | ----
 Old Baseline        |        80 |   46 |       57 |      52 |          95 |        0 |    0 |    1
-New Baseline        |        83 |   45 |       57 |      54 |          92 |        1 |    1 |    0
+New Baseline        |        83 |   45 |       57 |      54 |          93 |        0 |    2 |    2
 Old Oracle Entities |        89 |   56 |       56 |      66 |          95 |        0 |    7 |    8
-New Oracle Entities |        87 |   49 |       59 |      59 |          92 |        1 |    2 |    3
+New Oracle Entities |        87 | *49* |       59 |    *59* |          93 |        0 |  *2* |    6
 Old Oracle All      |       100 |   69 |       78 |      84 |         100 |       11 |   47 |   25
 New Oracle All      |       100 |   66 |       78 |      82 |         100 |       11 |   47 |   25
 

--- a/systems/baseline-template/text2sql-template-baseline.py
+++ b/systems/baseline-template/text2sql-template-baseline.py
@@ -112,16 +112,23 @@ def insert_variables(sql, sql_variables, sent, sent_variables):
     return (tokens, tags, ' '.join(template), ' '.join(complete))
 
 def get_tagged_data_for_query(data):
+    # By default, set to the query split value
     dataset = data['query-split']
+    if args.split is not None:
+        if str(args.split) == str(dataset):
+            dataset = "test"
+        else:
+            dataset = "train"
+
     for sent_info in data['sentences']:
+        # For question split, set to this question's value
         if not args.query_split:
             dataset = sent_info['question-split']
-
-        if args.split is not None:
-            if str(args.split) == str(dataset):
-                dataset = "test"
-            else:
-                dataset = "train"
+            if args.split is not None:
+                if str(args.split) == str(dataset):
+                    dataset = "test"
+                else:
+                    dataset = "train"
 
         for sql in data['sql']:
             sql_vars = {}


### PR DESCRIPTION
As described in issue #10, there was a bug in the handling of datasets where we do cross-validation.

This fixes it and updates the documentation to reflect the change.