### PR TITLE
Setting variable names to be type-based

### DIFF
--- a/data/geography.json
+++ b/data/geography.json
@@ -4,188 +4,188 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "arizona"
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what var0 city has the largest population",
+                "text": "what state0 city has the largest population",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "kansas"
+                    "state0": "kansas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "louisiana"
+                    "state0": "louisiana"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             },
             {
                 "question-split": "test",
-                "text": "where is the most populated area of var0",
+                "text": "where is the most populated area of state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which city in var0 has the largest population",
+                "text": "which city in state0 has the largest population",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "nebraska"
+                    "state0": "nebraska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what cities in var0 have the highest number of citizens",
+                "text": "what cities in state0 have the highest number of citizens",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what cities in var0 have the highest populations",
+                "text": "what cities in state0 have the highest populations",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the most populous city in var0",
+                "text": "what is the most populous city in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city in var0 by population",
+                "text": "what is the largest city in state0 by population",
                 "variables": {
-                    "var0": "minnesota"
+                    "state0": "minnesota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "oregon"
+                    "state0": "oregon"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the biggest city in var0",
+                "text": "what is the biggest city in state0",
                 "variables": {
-                    "var0": "georgia"
+                    "state0": "georgia"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city in var0",
+                "text": "what is the largest city in state0",
                 "variables": {
-                    "var0": "wisconsin"
+                    "state0": "wisconsin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city of var0",
+                "text": "what is the largest city of state0",
                 "variables": {
-                    "var0": "kansas"
+                    "state0": "kansas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the city in var0 with the largest population",
+                "text": "what is the city in state0 with the largest population",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the most populous city in var0",
+                "text": "what is the most populous city in state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"var0\" ) AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"state0\" ) AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "arizona",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -209,174 +209,174 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "how big is var0",
+                "text": "how big is state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "how big is var0",
+                "text": "how big is state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how large is var0",
+                "text": "how large is state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how large is var0",
+                "text": "how large is state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the area of the var0 state",
+                "text": "what is the area of the state0 state",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "wisconsin"
+                    "state0": "wisconsin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the size of var0",
+                "text": "what is the size of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0 in square kilometers",
+                "text": "what is the area of state0 in square kilometers",
                 "variables": {
-                    "var0": "maryland"
+                    "state0": "maryland"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the size of var0",
+                "text": "what is the size of state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "south carolina"
+                    "state0": "south carolina"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the size of var0",
+                "text": "what is the size of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how big is var0",
+                "text": "how big is state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "idaho"
+                    "state0": "idaho"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how big is var0",
+                "text": "how big is state0",
                 "variables": {
-                    "var0": "north dakota"
+                    "state0": "north dakota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how big is var0",
+                "text": "how big is state0",
                 "variables": {
-                    "var0": "massachusetts"
+                    "state0": "massachusetts"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the area of var0",
+                "text": "what is the area of state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.AREA FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT STATEalias0.AREA FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -386,300 +386,300 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people reside in var0",
+                "text": "how many people reside in state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many residents live in var0",
+                "text": "how many residents live in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how much population does var0 have",
+                "text": "how much population does state0 have",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the population of var0",
+                "text": "what are the population of state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "maryland"
+                    "state0": "maryland"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people are in the state of var0",
+                "text": "how many people are in the state of state0",
                 "variables": {
-                    "var0": "nevada"
+                    "state0": "nevada"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what can you tell me about the population of var0",
+                "text": "what can you tell me about the population of state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people are there in var0",
+                "text": "how many people are there in state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "oregon"
+                    "state0": "oregon"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "south dakota"
+                    "state0": "south dakota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "idaho"
+                    "state0": "idaho"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people are there in var0",
+                "text": "how many people are there in state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "kansas"
+                    "state0": "kansas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "new hampshire"
+                    "state0": "new hampshire"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many citizens in var0",
+                "text": "how many citizens in state0",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "arizona"
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "south dakota"
+                    "state0": "south dakota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "minnesota"
+                    "state0": "minnesota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people stay in var0",
+                "text": "how many people stay in state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many citizens live in var0",
+                "text": "how many citizens live in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "washington",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -713,62 +713,62 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "give me the cities in var0",
+                "text": "give me the cities in state0",
                 "variables": {
-                    "var0": "virginia"
+                    "state0": "virginia"
                 }
             },
             {
                 "question-split": "test",
-                "text": "tell me what cities are in var0",
+                "text": "tell me what cities are in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what cities are located in var0",
+                "text": "what cities are located in state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the cities in var0",
+                "text": "what are the cities in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "give me the cities in var0",
+                "text": "give me the cities in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what cities in var0",
+                "text": "what cities in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "give me the cities which are in var0",
+                "text": "give me the cities which are in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "virginia",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -778,20 +778,20 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what is the area of the state with the capital var0",
+                "text": "what is the area of the state with the capital city0",
                 "variables": {
-                    "var0": "albany"
+                    "city0": "albany"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.AREA FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ;"
+            "SELECT STATEalias0.AREA FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "albany",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -801,20 +801,20 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "give me the lakes in var0",
+                "text": "give me the lakes in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             }
         ],
         "sql": [
-            "SELECT LAKEalias0.LAKE_NAME FROM LAKE AS LAKEalias0 WHERE LAKEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT LAKEalias0.LAKE_NAME FROM LAKE AS LAKEalias0 WHERE LAKEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "california",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -824,20 +824,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "name the major lakes in var0",
+                "text": "name the major lakes in state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             }
         ],
         "sql": [
-            "SELECT LAKEalias0.LAKE_NAME FROM LAKE AS LAKEalias0 WHERE LAKEalias0.AREA > 750 AND LAKEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT LAKEalias0.LAKE_NAME FROM LAKE AS LAKEalias0 WHERE LAKEalias0.AREA > 750 AND LAKEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "california",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -871,181 +871,181 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "which states do var0 river flow through",
+                "text": "which states do river0 river flow through",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what states does the var0 river run through",
+                "text": "what states does the river0 river run through",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what states border the var0 river",
+                "text": "what states border the river0 river",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which states border the var0 river",
+                "text": "which states border the river0 river",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states does the var0 river run through",
+                "text": "what states does the river0 river run through",
                 "variables": {
-                    "var0": "delaware"
+                    "river0": "delaware"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states does the var0 river run through",
+                "text": "what states does the river0 river run through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states does the var0 run through",
+                "text": "what states does the river0 run through",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states does the var0 river run through",
+                "text": "what states does the river0 river run through",
                 "variables": {
-                    "var0": "ohio"
+                    "river0": "ohio"
                 }
             },
             {
                 "question-split": "test",
-                "text": "where is the var0 river",
+                "text": "where is the river0 river",
                 "variables": {
-                    "var0": "chattahoochee"
+                    "river0": "chattahoochee"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which states does the var0 river run through",
+                "text": "which states does the river0 river run through",
                 "variables": {
-                    "var0": "chattahoochee"
+                    "river0": "chattahoochee"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which states does the var0 run through",
+                "text": "which states does the river0 run through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states does the var0 river run through",
+                "text": "what states does the river0 river run through",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states does the var0 river pass through",
+                "text": "which states does the river0 river pass through",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states does the var0 run through",
+                "text": "what states does the river0 run through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states does the var0 river run through",
+                "text": "which states does the river0 river run through",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the states that the var0 run through",
+                "text": "what are the states that the river0 run through",
                 "variables": {
-                    "var0": "potomac"
+                    "river0": "potomac"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states does the var0 river run through",
+                "text": "which states does the river0 river run through",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which state has the var0 river",
+                "text": "which state has the river0 river",
                 "variables": {
-                    "var0": "red"
+                    "river0": "red"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states have rivers named var0",
+                "text": "what states have rivers named river0",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "through which states does the var0 flow",
+                "text": "through which states does the river0 flow",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states does the var0 river run through",
+                "text": "which states does the river0 river run through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states are next to the var0",
+                "text": "what states are next to the river0",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "through which states does the var0 run",
+                "text": "through which states does the river0 run",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states does the var0 river go through",
+                "text": "what states does the river0 river go through",
                 "variables": {
-                    "var0": "ohio"
+                    "river0": "ohio"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ;"
+            "SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -1114,20 +1114,20 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what is the lowest elevation in var0",
+                "text": "what is the lowest elevation in state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.LOWEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"var0\" ;"
+            "SELECT HIGHLOWalias0.LOWEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "pennsylvania",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -1170,90 +1170,90 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what is the longest river flowing through var0",
+                "text": "what is the longest river flowing through state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the largest river in var0 state",
+                "text": "what is the largest river in state0 state",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the longest river in var0",
+                "text": "what is the longest river in state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the biggest river in var0",
+                "text": "what is the biggest river in state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river in var0",
+                "text": "what is the longest river in state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river in var0",
+                "text": "what is the longest river in state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river that flows through var0",
+                "text": "what is the longest river that flows through state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the biggest rivers in var0",
+                "text": "what are the biggest rivers in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river in var0",
+                "text": "what is the longest river in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river in var0",
+                "text": "what is the longest river in state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river in var0",
+                "text": "what is the longest river in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"var0\" ) AND RIVERalias0.TRAVERSE = \"var0\" ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"state0\" ) AND RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "new york",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -1263,97 +1263,97 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "how many rivers are in var0",
+                "text": "how many rivers are in state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "give me the number of rivers in var0",
+                "text": "give me the number of rivers in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many rivers are in var0",
+                "text": "how many rivers are in state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many rivers does var0 have",
+                "text": "how many rivers does state0 have",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers are in var0",
+                "text": "how many rivers are in state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers are there in var0",
+                "text": "how many rivers are there in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers run through var0",
+                "text": "how many rivers run through state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers are found in var0",
+                "text": "how many rivers are found in state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers in var0",
+                "text": "how many rivers in state0",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers does var0 have",
+                "text": "how many rivers does state0 have",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers are in var0",
+                "text": "how many rivers are in state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers are there in var0",
+                "text": "how many rivers are there in state0",
                 "variables": {
-                    "var0": "idaho"
+                    "state0": "idaho"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE = \"var0\" ;"
+            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "new york",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -1363,314 +1363,314 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what states neighbor var0",
+                "text": "what states neighbor state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "delaware"
+                    "state0": "delaware"
                 }
             },
             {
                 "question-split": "test",
-                "text": "give me the states that border var0",
+                "text": "give me the states that border state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what state borders var0",
+                "text": "what state borders state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states are next to var0",
+                "text": "what states are next to state0",
                 "variables": {
-                    "var0": "arizona"
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "indiana"
+                    "state0": "indiana"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "new jersey"
+                    "state0": "new jersey"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states surround var0",
+                "text": "what states surround state0",
                 "variables": {
-                    "var0": "kentucky"
+                    "state0": "kentucky"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which state borders var0",
+                "text": "which state borders state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "kentucky"
+                    "state0": "kentucky"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states are next to var0",
+                "text": "what states are next to state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the neighboring states for var0",
+                "text": "what are the neighboring states for state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which state borders var0",
+                "text": "which state borders state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "georgia"
+                    "state0": "georgia"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "new hampshire"
+                    "state0": "new hampshire"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "south dakota"
+                    "state0": "south dakota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "arkansas"
+                    "state0": "arkansas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states adjoin var0",
+                "text": "which states adjoin state0",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state borders var0",
+                "text": "what state borders state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "states bordering var0",
+                "text": "states bordering state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which state border var0",
+                "text": "which state border state0",
                 "variables": {
-                    "var0": "kentucky"
+                    "state0": "kentucky"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the adjacent state of var0",
+                "text": "what is the adjacent state of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "wisconsin"
+                    "state0": "wisconsin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border var0",
+                "text": "which states border state0",
                 "variables": {
-                    "var0": "arizona"
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border var0",
+                "text": "what states border state0",
                 "variables": {
-                    "var0": "kentucky"
+                    "state0": "kentucky"
                 }
             }
         ],
         "sql": [
-            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ;"
+            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "maine",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -1680,223 +1680,223 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "name all the rivers in var0",
+                "text": "name all the rivers in state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "test",
-                "text": "rivers in var0",
+                "text": "rivers in state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are all the rivers in var0",
+                "text": "what are all the rivers in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the rivers in var0",
+                "text": "what are the rivers in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what rivers are in var0",
+                "text": "what rivers are in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what rivers are there in var0",
+                "text": "what rivers are there in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers flow through var0",
+                "text": "what rivers flow through state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "arizona"
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what river flows through var0",
+                "text": "what river flows through state0",
                 "variables": {
-                    "var0": "kansas"
+                    "state0": "kansas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the rivers in the state of var0",
+                "text": "what are the rivers in the state of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers are in var0",
+                "text": "what rivers are in state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "train",
-                "text": "name the rivers in var0",
+                "text": "name the rivers in state0",
                 "variables": {
-                    "var0": "arkansas"
+                    "state0": "arkansas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "louisiana"
+                    "state0": "louisiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "west virginia"
+                    "state0": "west virginia"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers are in var0",
+                "text": "what rivers are in state0",
                 "variables": {
-                    "var0": "nevada"
+                    "state0": "nevada"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers are in var0",
+                "text": "what rivers are in state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the rivers in the state of var0",
+                "text": "what are the rivers in the state of state0",
                 "variables": {
-                    "var0": "indiana"
+                    "state0": "indiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers flow through var0",
+                "text": "what rivers flow through state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the rivers of var0",
+                "text": "what are the rivers of state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which rivers are in var0",
+                "text": "which rivers are in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which rivers flow through var0",
+                "text": "which rivers flow through state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the river that cross over var0",
+                "text": "what is the river that cross over state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through var0",
+                "text": "what rivers run through state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what river flows through var0",
+                "text": "what river flows through state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what river runs through var0",
+                "text": "what river runs through state0",
                 "variables": {
-                    "var0": "virginia"
+                    "state0": "virginia"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers are in var0",
+                "text": "what rivers are in state0",
                 "variables": {
-                    "var0": "oregon"
+                    "state0": "oregon"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what river runs through var0",
+                "text": "what river runs through state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE = \"var0\" ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -1920,244 +1920,244 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what state is var0 in",
+                "text": "what state is city0 in",
                 "variables": {
-                    "var0": "dallas"
+                    "city0": "dallas"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "san diego"
+                    "city0": "san diego"
                 }
             },
             {
                 "question-split": "test",
-                "text": "var0 is in what state",
+                "text": "city0 is in what state",
                 "variables": {
-                    "var0": "san antonio"
+                    "city0": "san antonio"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what state is var0 in",
+                "text": "what state is city0 in",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what state is var0 in",
+                "text": "what state is city0 in",
                 "variables": {
-                    "var0": "miami"
+                    "city0": "miami"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states have cities named var0",
+                "text": "what states have cities named city0",
                 "variables": {
-                    "var0": "dallas"
+                    "city0": "dallas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states have cities named var0",
+                "text": "what states have cities named city0",
                 "variables": {
-                    "var0": "plano"
+                    "city0": "plano"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states have cities named var0",
+                "text": "what states have cities named city0",
                 "variables": {
-                    "var0": "portland"
+                    "city0": "portland"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states have cities named var0",
+                "text": "what states have cities named city0",
                 "variables": {
-                    "var0": "rochester"
+                    "city0": "rochester"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what states have cities named var0",
+                "text": "what states have cities named city0",
                 "variables": {
-                    "var0": "salt lake city"
+                    "city0": "salt lake city"
                 }
             },
             {
                 "question-split": "test",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "dallas"
+                    "city0": "dallas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "portland"
+                    "city0": "portland"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which states have cities named var0",
+                "text": "which states have cities named city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which state is var0 in",
+                "text": "which state is city0 in",
                 "variables": {
-                    "var0": "kalamazoo"
+                    "city0": "kalamazoo"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states have a city named var0",
+                "text": "what states have a city named city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state is var0 in",
+                "text": "what state is city0 in",
                 "variables": {
-                    "var0": "pittsburgh"
+                    "city0": "pittsburgh"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state has the city var0",
+                "text": "what state has the city city0",
                 "variables": {
-                    "var0": "flint"
+                    "city0": "flint"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states have towns named var0",
+                "text": "what states have towns named city0",
                 "variables": {
-                    "var0": "springfield"
+                    "city0": "springfield"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "san jose"
+                    "city0": "san jose"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "scotts valley"
+                    "city0": "scotts valley"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "new orleans"
+                    "city0": "new orleans"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "indianapolis"
+                    "city0": "indianapolis"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state is var0 located in",
+                "text": "what state is city0 located in",
                 "variables": {
-                    "var0": "des moines"
+                    "city0": "des moines"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states have cities named var0",
+                "text": "what states have cities named city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state is var0 in",
+                "text": "what state is city0 in",
                 "variables": {
-                    "var0": "boston"
+                    "city0": "boston"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "fort wayne"
+                    "city0": "fort wayne"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "houston"
+                    "city0": "houston"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "springfield"
+                    "city0": "springfield"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is city0",
                 "variables": {
-                    "var0": "baton rouge"
+                    "city0": "baton rouge"
                 }
             },
             {
                 "question-split": "train",
-                "text": "in which state is var0",
+                "text": "in which state is city0",
                 "variables": {
-                    "var0": "rochester"
+                    "city0": "rochester"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which state is the city var0 located in",
+                "text": "which state is the city city0 located in",
                 "variables": {
-                    "var0": "denver"
+                    "city0": "denver"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states in the united states have a city of var0",
+                "text": "what states in the united states have a city of city0",
                 "variables": {
-                    "var0": "springfield"
+                    "city0": "springfield"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.STATE_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"var0\" ;"
+            "SELECT CITYalias0.STATE_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "dallas",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -2186,209 +2186,209 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "chicago"
+                    "city0": "chicago"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "dallas"
+                    "city0": "dallas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people lived in var0",
+                "text": "how many people lived in city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "detroit"
+                    "city0": "detroit"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "houston"
+                    "city0": "houston"
                 }
             },
             {
                 "question-split": "test",
-                "text": "number of people in var0",
+                "text": "number of people in city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "houston"
+                    "city0": "houston"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0 city",
+                "text": "what is the population of city0 city",
                 "variables": {
-                    "var0": "new york"
+                    "city0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "san antonio"
+                    "city0": "san antonio"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "tucson"
+                    "city0": "tucson"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how big is the city of var0",
+                "text": "how big is the city of city0",
                 "variables": {
-                    "var0": "new york"
+                    "city0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "san francisco"
+                    "city0": "san francisco"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "sacramento"
+                    "city0": "sacramento"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "denver"
+                    "city0": "denver"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "seattle"
+                    "city0": "seattle"
                 }
             },
             {
                 "question-split": "train",
-                "text": "population of var0",
+                "text": "population of city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population in var0",
+                "text": "what is the population in city0",
                 "variables": {
-                    "var0": "boston"
+                    "city0": "boston"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "kalamazoo"
+                    "city0": "kalamazoo"
                 }
             },
             {
                 "question-split": "train",
-                "text": "people in var0",
+                "text": "people in city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people in var0",
+                "text": "how many people in city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many inhabitants does var0 have",
+                "text": "how many inhabitants does city0 have",
                 "variables": {
-                    "var0": "montgomery"
+                    "city0": "montgomery"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "riverside"
+                    "city0": "riverside"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0",
+                "text": "what is the population of city0",
                 "variables": {
-                    "var0": "atlanta"
+                    "city0": "atlanta"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0",
+                "text": "how many people live in city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "number of citizens in var0",
+                "text": "number of citizens in city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many citizens in var0",
+                "text": "how many citizens in city0",
                 "variables": {
-                    "var0": "boulder"
+                    "city0": "boulder"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"var0\" ;"
+            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "chicago",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -2398,41 +2398,41 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what is the smallest city in var0",
+                "text": "what is the smallest city in state0",
                 "variables": {
-                    "var0": "arkansas"
+                    "state0": "arkansas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the smallest city in var0",
+                "text": "what is the smallest city in state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the smallest city in var0",
+                "text": "what is the smallest city in state0",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the smallest city in var0",
+                "text": "what is the smallest city in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MIN( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"var0\" ) AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MIN( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"state0\" ) AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "arkansas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -2495,34 +2495,34 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "which states have points higher than the highest point in var0",
+                "text": "which states have points higher than the highest point in state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states have points that are higher than the highest point in var0",
+                "text": "which states have points that are higher than the highest point in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states high point are higher than that of var0",
+                "text": "what states high point are higher than that of state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.HIGHEST_ELEVATION > ( SELECT HIGHLOWalias1.HIGHEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.HIGHEST_ELEVATION > ( SELECT HIGHLOWalias1.HIGHEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -2532,83 +2532,83 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what is the highest elevation in var0",
+                "text": "what is the highest elevation in state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "how high is the highest point of var0",
+                "text": "how high is the highest point of state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how high is the highest point of var0",
+                "text": "how high is the highest point of state0",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how tall is the highest point in var0",
+                "text": "how tall is the highest point in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest elevation in var0",
+                "text": "what is the highest elevation in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in var0 in meters",
+                "text": "what is the highest point in state0 in meters",
                 "variables": {
-                    "var0": "nevada"
+                    "state0": "nevada"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how high is the highest point in var0",
+                "text": "how high is the highest point in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest elevation in var0",
+                "text": "what is the highest elevation in state0",
                 "variables": {
-                    "var0": "south carolina"
+                    "state0": "south carolina"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how high is the highest point of var0",
+                "text": "how high is the highest point of state0",
                 "variables": {
-                    "var0": "louisiana"
+                    "state0": "louisiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how high is the highest point of var0",
+                "text": "how high is the highest point of state0",
                 "variables": {
-                    "var0": "delaware"
+                    "state0": "delaware"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.HIGHEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"var0\" ;"
+            "SELECT HIGHLOWalias0.HIGHEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "new mexico",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -2774,27 +2774,27 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "what are the highest points of states surrounding var0",
+                "text": "what are the highest points of states surrounding state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the high points of states surrounding var0",
+                "text": "what are the high points of states surrounding state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -2804,27 +2804,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the highest point in states bordering var0",
+                "text": "what is the highest point in states bordering state0",
                 "variables": {
-                    "var0": "georgia"
+                    "state0": "georgia"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in the states bordering var0",
+                "text": "what is the highest point in the states bordering state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ORDER BY HIGHLOWalias0.HIGHEST_ELEVATION DESC LIMIT 1 ;"
+            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ORDER BY HIGHLOWalias0.HIGHEST_ELEVATION DESC LIMIT 1 ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -2902,146 +2902,146 @@
         "sentences": [
             {
                 "question-split": "dev",
-                "text": "where is the highest point in var0",
+                "text": "where is the highest point in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "virginia"
+                    "state0": "virginia"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the high point of var0",
+                "text": "what is the high point of state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             },
             {
                 "question-split": "test",
-                "text": "where is the highest point in var0",
+                "text": "where is the highest point in state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest mountain in var0",
+                "text": "what is the highest mountain in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "could you tell me what is the highest point in the state of var0",
+                "text": "could you tell me what is the highest point in the state of state0",
                 "variables": {
-                    "var0": "oregon"
+                    "state0": "oregon"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest mountain in var0",
+                "text": "what is the highest mountain in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "kansas"
+                    "state0": "kansas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "delaware"
+                    "state0": "delaware"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in var0",
+                "text": "what is the highest point in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"var0\" ;"
+            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "montana",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3119,20 +3119,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "count the states which have elevations lower than what var0 has",
+                "text": "count the states which have elevations lower than what state0 has",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( HIGHLOWalias0.STATE_NAME ) FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_ELEVATION < ( SELECT HIGHLOWalias1.LOWEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT COUNT( HIGHLOWalias0.STATE_NAME ) FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_ELEVATION < ( SELECT HIGHLOWalias1.LOWEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "alabama",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3142,41 +3142,41 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how high is var0",
+                "text": "how high is high_point0",
                 "variables": {
-                    "var0": "mount mckinley"
+                    "high_point0": "mount mckinley"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how tall is var0",
+                "text": "how tall is high_point0",
                 "variables": {
-                    "var0": "mount mckinley"
+                    "high_point0": "mount mckinley"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the maximum elevation of var0",
+                "text": "what is the maximum elevation of high_point0",
                 "variables": {
-                    "var0": "san francisco"
+                    "high_point0": "san francisco"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how high is var0",
+                "text": "how high is high_point0",
                 "variables": {
-                    "var0": "guadalupe peak"
+                    "high_point0": "guadalupe peak"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.HIGHEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.HIGHEST_POINT = \"var0\" ;"
+            "SELECT HIGHLOWalias0.HIGHEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.HIGHEST_POINT = \"high_point0\" ;"
         ],
         "variables": [
             {
                 "example": "mount mckinley",
                 "location": "both",
-                "name": "var0",
+                "name": "high_point0",
                 "type": "high_point"
             }
         ]
@@ -3215,104 +3215,104 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "delaware"
+                    "river0": "delaware"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "north platte"
+                    "river0": "north platte"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "ohio"
+                    "river0": "ohio"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the length of the var0 river",
+                "text": "what is the length of the river0 river",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the length of the var0 river",
+                "text": "what is the length of the river0 river",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what length is the var0",
+                "text": "what length is the river0",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how long is the var0",
+                "text": "how long is the river0",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how long is the var0 river in miles",
+                "text": "how long is the river0 river in miles",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "rio grande"
+                    "river0": "rio grande"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how long is the var0 river",
+                "text": "how long is the river0 river",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how long is var0",
+                "text": "how long is river0",
                 "variables": {
-                    "var0": "rio grande"
+                    "river0": "rio grande"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT RIVERalias0.LENGTH FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ;"
+            "SELECT DISTINCT RIVERalias0.LENGTH FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -3322,27 +3322,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how long is the longest river in var0",
+                "text": "how long is the longest river in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the length of the longest river that runs through var0",
+                "text": "what is the length of the longest river that runs through state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.LENGTH FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"var0\" ) AND RIVERalias0.TRAVERSE = \"var0\" ;"
+            "SELECT RIVERalias0.LENGTH FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"state0\" ) AND RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "california",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3352,20 +3352,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how many capitals does var0 have",
+                "text": "how many capitals does state0 have",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( STATEalias0.CAPITAL ) FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT COUNT( STATEalias0.CAPITAL ) FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "rhode island",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3437,27 +3437,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how many var0 rivers are there",
+                "text": "how many river0 rivers are there",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many rivers are called var0",
+                "text": "how many rivers are called river0",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ;"
+            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -3467,131 +3467,131 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "washington",
-                    "var1": "dc"
+                    "city0": "washington",
+                    "state0": "dc"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0 var1",
+                "text": "how many people live in city0 state0",
                 "variables": {
-                    "var0": "washington",
-                    "var1": "dc"
+                    "city0": "washington",
+                    "state0": "dc"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many people live in var0 var1",
+                "text": "how many people live in city0 state0",
                 "variables": {
-                    "var0": "minneapolis",
-                    "var1": "minnesota"
+                    "city0": "minneapolis",
+                    "state0": "minnesota"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "atlanta",
-                    "var1": "georgia"
+                    "city0": "atlanta",
+                    "state0": "georgia"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "erie",
-                    "var1": "pennsylvania"
+                    "city0": "erie",
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "tempe",
-                    "var1": "arizona"
+                    "city0": "tempe",
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "boston",
-                    "var1": "massachusetts"
+                    "city0": "boston",
+                    "state0": "massachusetts"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "springfield",
-                    "var1": "missouri"
+                    "city0": "springfield",
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "springfield",
-                    "var1": "south dakota"
+                    "city0": "springfield",
+                    "state0": "south dakota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0 var1",
+                "text": "how many people live in city0 state0",
                 "variables": {
-                    "var0": "austin",
-                    "var1": "texas"
+                    "city0": "austin",
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "portland",
-                    "var1": "maine"
+                    "city0": "portland",
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in var0 var1",
+                "text": "how many people live in city0 state0",
                 "variables": {
-                    "var0": "spokane",
-                    "var1": "washington"
+                    "city0": "spokane",
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "austin",
-                    "var1": "texas"
+                    "city0": "austin",
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of var0 var1",
+                "text": "what is the population of city0 state0",
                 "variables": {
-                    "var0": "seattle",
-                    "var1": "washington"
+                    "city0": "seattle",
+                    "state0": "washington"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"var0\" AND CITYalias0.STATE_NAME = \"var1\" ;"
+            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"city0\" AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "minneapolis",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             },
             {
                 "example": "minnesota",
                 "location": "both",
-                "name": "var1",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3601,27 +3601,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how many people live in the biggest city in var0 state",
+                "text": "how many people live in the biggest city in state0 state",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how large is the largest city in var0",
+                "text": "how large is the largest city in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"var0\" ) AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"state0\" ) AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "new york",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3631,34 +3631,34 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how many people live in the capital of var0",
+                "text": "how many people live in the capital of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many people live in the capital of var0",
+                "text": "how many people live in the capital of state0",
                 "variables": {
-                    "var0": "georgia"
+                    "state0": "georgia"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the size of the capital of var0",
+                "text": "what is the size of the capital of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = ( SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = ( SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3741,90 +3741,90 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "how many states border var0",
+                "text": "how many states border state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "test",
-                "text": "how many states does var0 border",
+                "text": "how many states does state0 border",
                 "variables": {
-                    "var0": "tennessee"
+                    "state0": "tennessee"
                 }
             },
             {
                 "question-split": "test",
-                "text": "var0 borders how many states",
+                "text": "state0 borders how many states",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "test",
-                "text": "number of states bordering var0",
+                "text": "number of states bordering state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states border var0",
+                "text": "how many states border state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states border var0",
+                "text": "how many states border state0",
                 "variables": {
-                    "var0": "tennessee"
+                    "state0": "tennessee"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states does var0 border",
+                "text": "how many states does state0 border",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states border var0",
+                "text": "how many states border state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states does var0 border",
+                "text": "how many states does state0 border",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states border var0",
+                "text": "how many states border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the number of neighboring states for var0",
+                "text": "what is the number of neighboring states for state0",
                 "variables": {
-                    "var0": "kentucky"
+                    "state0": "kentucky"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ;"
+            "SELECT COUNT( BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "iowa",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3876,41 +3876,41 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "name the major rivers in var0",
+                "text": "name the major rivers in state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the major rivers in var0",
+                "text": "what are the major rivers in state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "dev",
-                "text": "what are major rivers in var0",
+                "text": "what are major rivers in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what major rivers run through var0",
+                "text": "what major rivers run through state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 AND RIVERalias0.TRAVERSE = \"var0\" ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 AND RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "florida",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3920,20 +3920,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "through which states does the longest river in var0 run",
+                "text": "through which states does the longest river in state0 run",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"var0\" ) ;"
+            "SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -3943,202 +3943,202 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the capital city in var0",
+                "text": "what are the capital city in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "massachusetts"
+                    "state0": "massachusetts"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "new jersey"
+                    "state0": "new jersey"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "north dakota"
+                    "state0": "north dakota"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the capital of the var0 state",
+                "text": "what is the capital of the state0 state",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "maryland"
+                    "state0": "maryland"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is capital of var0",
+                "text": "what is capital of state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "vermont"
+                    "state0": "vermont"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "georgia"
+                    "state0": "georgia"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of the state var0",
+                "text": "what is the capital of the state state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "washington"
+                    "state0": "washington"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "indiana"
+                    "state0": "indiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of the var0 state",
+                "text": "what is the capital of the state0 state",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "michigan"
+                    "state0": "michigan"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "hawaii"
+                    "state0": "hawaii"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the capital of var0",
+                "text": "what is the capital of state0",
                 "variables": {
-                    "var0": "new hampshire"
+                    "state0": "new hampshire"
                 }
             },
             {
                 "question-split": "train",
-                "text": "can you tell me the capital of var0",
+                "text": "can you tell me the capital of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -4148,41 +4148,41 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the capitals of states that border var0",
+                "text": "what are the capitals of states that border state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the capital cities of the states which border var0",
+                "text": "what are the capital cities of the states which border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the capitals of the states that border var0",
+                "text": "what are the capitals of the states that border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which capitals are in the states that border var0",
+                "text": "which capitals are in the states that border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.CAPITAL FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
+            "SELECT STATEalias0.CAPITAL FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
         ],
         "variables": [
             {
                 "example": "missouri",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -4192,20 +4192,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the cities in states through which the var0 runs",
+                "text": "what are the cities in states through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -4243,160 +4243,160 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the major cities in the state of var0",
+                "text": "what are the major cities in the state of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "vermont"
+                    "state0": "vermont"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what major cities are located in var0",
+                "text": "what major cities are located in state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "oklahoma"
+                    "state0": "oklahoma"
                 }
             },
             {
                 "question-split": "train",
-                "text": "show major cities in var0",
+                "text": "show major cities in state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the names of the major cities in var0",
+                "text": "what are the names of the major cities in state0",
                 "variables": {
-                    "var0": "illinois"
+                    "state0": "illinois"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "north carolina"
+                    "state0": "north carolina"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities of var0",
+                "text": "what are the major cities of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "delaware"
+                    "state0": "delaware"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the major cities in var0",
+                "text": "what is the major cities in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "rhode island"
+                    "state0": "rhode island"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "missouri"
+                    "state0": "missouri"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the major cities in var0",
+                "text": "what are the major cities in state0",
                 "variables": {
-                    "var0": "kansas"
+                    "state0": "kansas"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "alabama",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -4406,20 +4406,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the major cities in states through which the var0 runs",
+                "text": "what are the major cities in states through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 AND RIVERalias0.RIVER_NAME = \"var0\" ) ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 AND RIVERalias0.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -4467,69 +4467,69 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the populations of states through which the var0 river run",
+                "text": "what are the populations of states through which the river0 river run",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what are the populations of states through which the var0 runs",
+                "text": "what are the populations of states through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of the states through which the var0 runs",
+                "text": "what are the populations of the states through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of states through which the var0 river runs",
+                "text": "what are the populations of states through which the river0 river runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of the states through which the var0 run",
+                "text": "what are the populations of the states through which the river0 run",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of the states through which the var0 river run",
+                "text": "what are the populations of the states through which the river0 river run",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of states through which the var0 run",
+                "text": "what are the populations of states through which the river0 run",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of the states through which the var0 river runs",
+                "text": "what are the populations of the states through which the river0 river runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -4539,20 +4539,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the populations of states which border var0",
+                "text": "what are the populations of states which border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.POPULATION FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
+            "SELECT STATEalias0.POPULATION FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -4562,34 +4562,34 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what are the populations of the major cities of var0",
+                "text": "what are the populations of the major cities of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what are the populations of all the major cities in var0",
+                "text": "what are the populations of all the major cities in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population of the major cities in var0",
+                "text": "what is the population of the major cities in state0",
                 "variables": {
-                    "var0": "wisconsin"
+                    "state0": "wisconsin"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -4730,20 +4730,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the capital of states that have cities named var0",
+                "text": "what is the capital of states that have cities named city0",
                 "variables": {
-                    "var0": "durham"
+                    "city0": "durham"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.CAPITAL FROM CITY AS CITYalias0 , STATE AS STATEalias0 WHERE CITYalias0.CITY_NAME = \"var0\" AND STATEalias0.STATE_NAME = CITYalias0.STATE_NAME ;"
+            "SELECT STATEalias0.CAPITAL FROM CITY AS CITYalias0 , STATE AS STATEalias0 WHERE CITYalias0.CITY_NAME = \"city0\" AND STATEalias0.STATE_NAME = CITYalias0.STATE_NAME ;"
         ],
         "variables": [
             {
                 "example": "durham",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -4843,55 +4843,55 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the density of the var0",
+                "text": "what is the density of the state0",
                 "variables": {
-                    "var0": "new york"
+                    "state0": "new york"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the population density of var0",
+                "text": "what is the population density of state0",
                 "variables": {
-                    "var0": "maine"
+                    "state0": "maine"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population density of var0",
+                "text": "what is the population density of state0",
                 "variables": {
-                    "var0": "south dakota"
+                    "state0": "south dakota"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population density of var0",
+                "text": "what is the population density of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the density of var0",
+                "text": "what is the density of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the population density of var0",
+                "text": "what is the population density of state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.DENSITY FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT STATEalias0.DENSITY FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "new york",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -4930,34 +4930,34 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the highest point in the state with capital var0",
+                "text": "what is the highest point in the state with capital city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in the state with capital var0",
+                "text": "what is the highest point in the state with capital city0",
                 "variables": {
-                    "var0": "des moines"
+                    "city0": "des moines"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the highest point in the state with the capital var0",
+                "text": "what is the highest point in the state with the capital city0",
                 "variables": {
-                    "var0": "des moines"
+                    "city0": "des moines"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ) ;"
+            "SELECT HIGHLOWalias0.HIGHEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ) ;"
         ],
         "variables": [
             {
                 "example": "austin",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -5015,20 +5015,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the largest city in smallest state through which the var0 runs",
+                "text": "what is the largest city in smallest state through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"var0\" ) AND STATEalias0.AREA = ( SELECT MIN( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ) ) ORDER BY CITYalias0.POPULATION DESC LIMIT 1 ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"river0\" ) AND STATEalias0.AREA = ( SELECT MIN( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ) ) ORDER BY CITYalias0.POPULATION DESC LIMIT 1 ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -5057,50 +5057,50 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the largest state bordering var0",
+                "text": "what is the largest state bordering state0",
                 "variables": {
-                    "var0": "arkansas"
+                    "state0": "arkansas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the largest state that borders var0",
+                "text": "what is the largest state that borders state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest state bordering var0",
+                "text": "what is the largest state bordering state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state that borders var0 is the largest",
+                "text": "what state that borders state0 is the largest",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest state that borders var0",
+                "text": "what is the largest state that borders state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;",
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ORDER BY STATEalias0.AREA DESC LIMIT 1 ;",
-            "SELECT STATEalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" AND STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM BORDER_INFO AS BORDER_INFOalias1 , STATE AS STATEalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" AND STATEalias1.STATE_NAME = BORDER_INFOalias1.BORDER ) AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;",
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ORDER BY STATEalias0.AREA DESC LIMIT 1 ;",
+            "SELECT STATEalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" AND STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM BORDER_INFO AS BORDER_INFOalias1 , STATE AS STATEalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" AND STATEalias1.STATE_NAME = BORDER_INFOalias1.BORDER ) AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
         ],
         "variables": [
             {
                 "example": "arkansas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5153,35 +5153,35 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the longest river in the states that border var0",
+                "text": "what is the longest river in the states that border state0",
                 "variables": {
-                    "var0": "nebraska"
+                    "state0": "nebraska"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the longest river that flows through a state that borders var0",
+                "text": "what is the longest river that flows through a state that borders state0",
                 "variables": {
-                    "var0": "indiana"
+                    "state0": "indiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the longest river that runs through a state that borders var0",
+                "text": "what is the longest river that runs through a state that borders state0",
                 "variables": {
-                    "var0": "tennessee"
+                    "state0": "tennessee"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;",
-            "SELECT RIVERalias0.RIVER_NAME FROM BORDER_INFO AS BORDER_INFOalias0 , RIVER AS RIVERalias0 WHERE BORDER_INFOalias0.BORDER = \"var0\" AND RIVERalias0.TRAVERSE = BORDER_INFOalias0.STATE_NAME ORDER BY RIVERalias0.LENGTH DESC LIMIT 1 ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;",
+            "SELECT RIVERalias0.RIVER_NAME FROM BORDER_INFO AS BORDER_INFOalias0 , RIVER AS RIVERalias0 WHERE BORDER_INFOalias0.BORDER = \"state0\" AND RIVERalias0.TRAVERSE = BORDER_INFOalias0.STATE_NAME ORDER BY RIVERalias0.LENGTH DESC LIMIT 1 ;"
         ],
         "variables": [
             {
                 "example": "nebraska",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5205,111 +5205,111 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "arkansas"
+                    "state0": "arkansas"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "massachusetts"
+                    "state0": "massachusetts"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the lowest point in var0 in meters",
+                "text": "what is the lowest point in state0 in meters",
                 "variables": {
-                    "var0": "nebraska"
+                    "state0": "nebraska"
                 }
             },
             {
                 "question-split": "test",
-                "text": "what is the lowest point in the state of var0",
+                "text": "what is the lowest point in the state of state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "test",
-                "text": "where is the lowest point in var0",
+                "text": "where is the lowest point in state0",
                 "variables": {
-                    "var0": "maryland"
+                    "state0": "maryland"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "wisconsin"
+                    "state0": "wisconsin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "oregon"
+                    "state0": "oregon"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "louisiana"
+                    "state0": "louisiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point in the state of var0",
+                "text": "what is the lowest point in the state of state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point in var0",
+                "text": "what is the lowest point in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the lowest point of var0",
+                "text": "what is the lowest point of state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is the lowest spot in var0",
+                "text": "where is the lowest spot in state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.LOWEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"var0\" ;"
+            "SELECT HIGHLOWalias0.LOWEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "arkansas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5348,27 +5348,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the lowest point of all states through which the var0 river runs through",
+                "text": "what is the lowest point of all states through which the river0 river runs through",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which is the lowest point of the states that the var0 runs through",
+                "text": "which is the lowest point of the states that the river0 runs through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.LOWEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ORDER BY HIGHLOWalias0.LOWEST_ELEVATION LIMIT 1 ;"
+            "SELECT HIGHLOWalias0.LOWEST_POINT FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ORDER BY HIGHLOWalias0.LOWEST_ELEVATION LIMIT 1 ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -5432,28 +5432,28 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the most populous state through which the var0 runs",
+                "text": "what is the most populous state through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state which the var0 runs through has the largest population",
+                "text": "what state which the river0 runs through has the largest population",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"var0\" ) ;",
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ORDER BY STATEalias0.POPULATION DESC LIMIT 1 ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"river0\" ) ;",
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ORDER BY STATEalias0.POPULATION DESC LIMIT 1 ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -5581,41 +5581,41 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the smallest state bordering var0",
+                "text": "what is the smallest state bordering state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the smallest state that borders var0",
+                "text": "what is the smallest state that borders state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the smallest state bordering var0",
+                "text": "what is the smallest state bordering state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which state has the smallest area that borders var0",
+                "text": "which state has the smallest area that borders state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MIN( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MIN( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "wyoming",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5625,20 +5625,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what is the smallest state that the var0 river runs through",
+                "text": "what is the smallest state that the river0 river runs through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MIN( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MIN( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -5759,34 +5759,34 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what rivers are in states that border var0",
+                "text": "what rivers are in states that border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which rivers run through states bordering var0",
+                "text": "which rivers run through states bordering state0",
                 "variables": {
-                    "var0": "new mexico"
+                    "state0": "new mexico"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers flow through states that var0 borders",
+                "text": "what rivers flow through states that state0 borders",
                 "variables": {
-                    "var0": "alabama"
+                    "state0": "alabama"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5815,43 +5815,43 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what state bordering var0 has the largest population",
+                "text": "what state bordering state0 has the largest population",
                 "variables": {
-                    "var0": "nevada"
+                    "state0": "nevada"
                 }
             },
             {
                 "question-split": "test",
-                "text": "which of the states bordering var0 has the largest population",
+                "text": "which of the states bordering state0 has the largest population",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state that borders var0 has the highest population",
+                "text": "what state that borders state0 has the highest population",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the most populated state bordering var0",
+                "text": "what is the most populated state bordering state0",
                 "variables": {
-                    "var0": "oklahoma"
+                    "state0": "oklahoma"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ORDER BY STATEalias0.POPULATION DESC LIMIT 1 ;",
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;",
-            "SELECT DISTINCT STATEalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" AND STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM BORDER_INFO AS BORDER_INFOalias1 , STATE AS STATEalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" AND STATEalias1.STATE_NAME = BORDER_INFOalias1.BORDER ) AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ORDER BY STATEalias0.POPULATION DESC LIMIT 1 ;",
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;",
+            "SELECT DISTINCT STATEalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" AND STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM BORDER_INFO AS BORDER_INFOalias1 , STATE AS STATEalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" AND STATEalias1.STATE_NAME = BORDER_INFOalias1.BORDER ) AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
         ],
         "variables": [
             {
                 "example": "nevada",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5861,20 +5861,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what state contains the highest point of those the var0 river traverses",
+                "text": "what state contains the highest point of those the river0 river traverses",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.HIGHEST_ELEVATION = ( SELECT MAX( HIGHLOWalias1.HIGHEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ) ;"
+            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.HIGHEST_ELEVATION = ( SELECT MAX( HIGHLOWalias1.HIGHEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ) ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -5950,27 +5950,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what states border states that border var0",
+                "text": "what states border states that border state0",
                 "variables": {
-                    "var0": "mississippi"
+                    "state0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border states that border var0",
+                "text": "what states border states that border state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -5980,41 +5980,41 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what states border states that the var0 runs through",
+                "text": "what states border states that the river0 runs through",
                 "variables": {
-                    "var0": "ohio"
+                    "river0": "ohio"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border states that the var0 runs through",
+                "text": "what states border states that the river0 runs through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "which states border states through which the var0 traverses",
+                "text": "which states border states through which the river0 traverses",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states border states which the var0 runs through",
+                "text": "what states border states which the river0 runs through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ;"
+            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "ohio",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -6024,20 +6024,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "what states border var0 and have a major river",
+                "text": "what states border state0 and have a major river",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT BORDER_INFOalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.BORDER = \"var0\" AND BORDER_INFOalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 ) ;"
+            "SELECT BORDER_INFOalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.BORDER = \"state0\" AND BORDER_INFOalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6208,20 +6208,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "which is the highest peak not in var0",
+                "text": "which is the highest peak not in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             }
         ],
         "sql": [
-            "SELECT MOUNTAINalias0.MOUNTAIN_NAME FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.MOUNTAIN_ALTITUDE = ( SELECT MAX( MOUNTAINalias1.MOUNTAIN_ALTITUDE ) FROM MOUNTAIN AS MOUNTAINalias1 WHERE MOUNTAINalias1.STATE_NAME <> \"var0\" ) ;"
+            "SELECT MOUNTAINalias0.MOUNTAIN_NAME FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.MOUNTAIN_ALTITUDE = ( SELECT MAX( MOUNTAINalias1.MOUNTAIN_ALTITUDE ) FROM MOUNTAIN AS MOUNTAINalias1 WHERE MOUNTAINalias1.STATE_NAME <> \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "alaska",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6231,27 +6231,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "which rivers do not run through var0",
+                "text": "which rivers do not run through state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers do not run through var0",
+                "text": "what rivers do not run through state0",
                 "variables": {
-                    "var0": "tennessee"
+                    "state0": "tennessee"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME NOT IN ( SELECT RIVERalias1.RIVER_NAME FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"var0\" ) ;"
+            "SELECT DISTINCT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME NOT IN ( SELECT RIVERalias1.RIVER_NAME FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6261,20 +6261,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "which rivers do not run through var0",
+                "text": "which rivers do not run through country0",
                 "variables": {
-                    "var0": "usa"
+                    "country0": "usa"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.COUNTRY_NAME <> \"var0\" ;"
+            "SELECT DISTINCT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.COUNTRY_NAME <> \"country0\" ;"
         ],
         "variables": [
             {
                 "example": "usa",
                 "location": "both",
-                "name": "var0",
+                "name": "country0",
                 "type": "country"
             }
         ]
@@ -6284,27 +6284,27 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "which rivers run through states that border the state with the capital var0",
+                "text": "which rivers run through states that border the state with the capital city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what rivers run through the states that border the state with the capital var0",
+                "text": "what rivers run through the states that border the state with the capital city0",
                 "variables": {
-                    "var0": "atlanta"
+                    "city0": "atlanta"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ) ) ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ) ) ;"
         ],
         "variables": [
             {
                 "example": "austin",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -6415,20 +6415,20 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "which state has the lowest point that borders var0",
+                "text": "which state has the lowest point that borders state0",
                 "variables": {
-                    "var0": "idaho"
+                    "state0": "idaho"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_ELEVATION = ( SELECT MIN( HIGHLOWalias1.LOWEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND HIGHLOWalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_ELEVATION = ( SELECT MIN( HIGHLOWalias1.LOWEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias1 WHERE HIGHLOWalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND HIGHLOWalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "idaho",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6476,41 +6476,41 @@
         "sentences": [
             {
                 "question-split": "test",
-                "text": "which state is mount var0 in",
+                "text": "which state is mount mountain0 in",
                 "variables": {
-                    "var0": "mckinley"
+                    "mountain0": "mckinley"
                 }
             },
             {
                 "question-split": "train",
-                "text": "in what state is mount var0",
+                "text": "in what state is mount mountain0",
                 "variables": {
-                    "var0": "mckinley"
+                    "mountain0": "mckinley"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is mount var0",
+                "text": "where is mount mountain0",
                 "variables": {
-                    "var0": "whitney"
+                    "mountain0": "whitney"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is mount var0 located",
+                "text": "where is mount mountain0 located",
                 "variables": {
-                    "var0": "whitney"
+                    "mountain0": "whitney"
                 }
             }
         ],
         "sql": [
-            "SELECT MOUNTAINalias0.STATE_NAME FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.MOUNTAIN_NAME = \"var0\" ;"
+            "SELECT MOUNTAINalias0.STATE_NAME FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.MOUNTAIN_NAME = \"mountain0\" ;"
         ],
         "variables": [
             {
                 "example": "mckinley",
                 "location": "both",
-                "name": "var0",
+                "name": "mountain0",
                 "type": "mountain"
             }
         ]
@@ -6539,20 +6539,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "which states have a major city named var0",
+                "text": "which states have a major city named city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.STATE_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"var0\" AND CITYalias0.POPULATION > 150000 ;"
+            "SELECT CITYalias0.STATE_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"city0\" AND CITYalias0.POPULATION > 150000 ;"
         ],
         "variables": [
             {
                 "example": "austin",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -6562,28 +6562,28 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the largest city in a state that borders var0",
+                "text": "what is the largest city in a state that borders state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest city in states that border var0",
+                "text": "what is the largest city in states that border state0",
                 "variables": {
-                    "var0": "california"
+                    "state0": "california"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND CITYalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;",
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.BORDER = \"var0\" ) ) AND CITYalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.BORDER = \"var0\" ) ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND CITYalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;",
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.BORDER = \"state0\" ) ) AND CITYalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.STATE_NAME FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.BORDER = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6593,20 +6593,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many rivers do not traverse the state with the capital var0",
+                "text": "how many rivers do not traverse the state with the capital city0",
                 "variables": {
-                    "var0": "albany"
+                    "city0": "albany"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( DISTINCT RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME NOT IN ( SELECT RIVERalias1.RIVER_NAME FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ) ) ;"
+            "SELECT COUNT( DISTINCT RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME NOT IN ( SELECT RIVERalias1.RIVER_NAME FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE IN ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ) ) ;"
         ],
         "variables": [
             {
                 "example": "albany",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -6616,42 +6616,42 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the shortest river in var0",
+                "text": "what is the shortest river in state0",
                 "variables": {
-                    "var0": "iowa"
+                    "state0": "iowa"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the shortest river in var0",
+                "text": "what is the shortest river in state0",
                 "variables": {
-                    "var0": "nebraska"
+                    "state0": "nebraska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the shortest river in var0",
+                "text": "what is the shortest river in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the shortest river in var0",
+                "text": "what is the shortest river in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MIN( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"var0\" ) AND RIVERalias0.TRAVERSE = \"var0\" ;",
-            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE = \"var0\" ORDER BY RIVERalias0.LENGTH LIMIT 1 ;"
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = ( SELECT MIN( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.TRAVERSE = \"state0\" ) AND RIVERalias0.TRAVERSE = \"state0\" ;",
+            "SELECT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE = \"state0\" ORDER BY RIVERalias0.LENGTH LIMIT 1 ;"
         ],
         "variables": [
             {
                 "example": "iowa",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6675,20 +6675,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the population of the capital of the largest state through which the var0 runs",
+                "text": "what is the population of the capital of the largest state through which the river0 runs",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = ( SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM RIVER AS RIVERalias0 , STATE AS STATEalias1 WHERE RIVERalias0.RIVER_NAME = \"var0\" AND STATEalias1.STATE_NAME = RIVERalias0.TRAVERSE ) ) ;"
+            "SELECT CITYalias0.POPULATION FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = ( SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM RIVER AS RIVERalias0 , STATE AS STATEalias1 WHERE RIVERalias0.RIVER_NAME = \"river0\" AND STATEalias1.STATE_NAME = RIVERalias0.TRAVERSE ) ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -6733,20 +6733,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the capital of the state that borders the state that borders var0",
+                "text": "what is the capital of the state that borders the state that borders state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ) ;"
+            "SELECT STATEalias0.CAPITAL FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6798,20 +6798,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the population of the largest state that borders var0",
+                "text": "what is the population of the largest state that borders state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -6821,48 +6821,48 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what state is var0 the capital of",
+                "text": "what state is city0 the capital of",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what states capital is var0",
+                "text": "what states capital is city0",
                 "variables": {
-                    "var0": "dover"
+                    "city0": "dover"
                 }
             },
             {
                 "question-split": "train",
-                "text": "var0 is the capital of which state",
+                "text": "city0 is the capital of which state",
                 "variables": {
-                    "var0": "sacramento"
+                    "city0": "sacramento"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state is var0 the capital of",
+                "text": "what state is city0 the capital of",
                 "variables": {
-                    "var0": "columbus"
+                    "city0": "columbus"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what state has the capital var0",
+                "text": "what state has the capital city0",
                 "variables": {
-                    "var0": "salem"
+                    "city0": "salem"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "austin",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -6947,41 +6947,41 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many states have a city named var0",
+                "text": "how many states have a city named city0",
                 "variables": {
-                    "var0": "springfield"
+                    "city0": "springfield"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states have a city called var0",
+                "text": "how many states have a city called city0",
                 "variables": {
-                    "var0": "rochester"
+                    "city0": "rochester"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states have cities named var0",
+                "text": "how many states have cities named city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states have cities or towns named var0",
+                "text": "how many states have cities or towns named city0",
                 "variables": {
-                    "var0": "springfield"
+                    "city0": "springfield"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( CITYalias0.STATE_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"var0\" ;"
+            "SELECT COUNT( CITYalias0.STATE_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "springfield",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -7044,20 +7044,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what are the lakes in states bordering var0",
+                "text": "what are the lakes in states bordering state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT LAKEalias0.LAKE_NAME FROM LAKE AS LAKEalias0 WHERE LAKEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT LAKEalias0.LAKE_NAME FROM LAKE AS LAKEalias0 WHERE LAKEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7067,48 +7067,48 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many major cities are in var0",
+                "text": "how many major cities are in state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many major cities are in var0",
+                "text": "how many major cities are in state0",
                 "variables": {
-                    "var0": "arizona"
+                    "state0": "arizona"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many big cities are in var0",
+                "text": "how many big cities are in state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many major cities are there in var0",
+                "text": "how many major cities are there in state0",
                 "variables": {
-                    "var0": "oregon"
+                    "state0": "oregon"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many major cities are in var0",
+                "text": "how many major cities are in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "florida",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7132,48 +7132,48 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many states does the var0 run through",
+                "text": "how many states does the river0 run through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states does the var0 river flow through",
+                "text": "how many states does the river0 river flow through",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states does the var0 river run through",
+                "text": "how many states does the river0 river run through",
                 "variables": {
-                    "var0": "colorado"
+                    "river0": "colorado"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states does the var0 river run through",
+                "text": "how many states does the river0 river run through",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many states does the var0 river run through",
+                "text": "how many states does the river0 river run through",
                 "variables": {
-                    "var0": "missouri"
+                    "river0": "missouri"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( RIVERalias0.TRAVERSE ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ;"
+            "SELECT COUNT( RIVERalias0.TRAVERSE ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -7197,20 +7197,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the average population per square km in var0",
+                "text": "what is the average population per square km in state0",
                 "variables": {
-                    "var0": "pennsylvania"
+                    "state0": "pennsylvania"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.POPULATION / STATEalias0.AREA FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT STATEalias0.POPULATION / STATEalias0.AREA FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "pennsylvania",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7220,20 +7220,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what states border states that border states that border var0",
+                "text": "what states border states that border states that border state0",
                 "variables": {
-                    "var0": "florida"
+                    "state0": "florida"
                 }
             }
         ],
         "sql": [
-            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME IN ( SELECT BORDER_INFOalias2.BORDER FROM BORDER_INFO AS BORDER_INFOalias2 WHERE BORDER_INFOalias2.STATE_NAME = \"var0\" ) ) ;"
+            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME IN ( SELECT BORDER_INFOalias2.BORDER FROM BORDER_INFO AS BORDER_INFOalias2 WHERE BORDER_INFOalias2.STATE_NAME = \"state0\" ) ) ;"
         ],
         "variables": [
             {
                 "example": "florida",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7257,20 +7257,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the height of the highest mountain in var0",
+                "text": "what is the height of the highest mountain in state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT MAX( DISTINCT HIGHLOWalias0.HIGHEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"var0\" ;"
+            "SELECT MAX( DISTINCT HIGHLOWalias0.HIGHEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7280,27 +7280,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many states border var1 and border var0",
+                "text": "how many states border state1 and border state0",
                 "variables": {
-                    "var0": "new mexico",
-                    "var1": "colorado"
+                    "state0": "new mexico",
+                    "state1": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.BORDER IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) AND BORDER_INFOalias0.STATE_NAME = \"var1\" ;"
+            "SELECT COUNT( BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.BORDER IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) AND BORDER_INFOalias0.STATE_NAME = \"state1\" ;"
         ],
         "variables": [
             {
                 "example": "new mexico",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             },
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var1",
+                "name": "state1",
                 "type": "state"
             }
         ]
@@ -7310,27 +7310,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many major cities are in states bordering var0",
+                "text": "how many major cities are in states bordering state0",
                 "variables": {
-                    "var0": "utah"
+                    "state0": "utah"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many major cities are in states bordering var0",
+                "text": "how many major cities are in states bordering state0",
                 "variables": {
-                    "var0": "nebraska"
+                    "state0": "nebraska"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "utah",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7340,20 +7340,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the total population of the states that border var0",
+                "text": "what is the total population of the states that border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT SUM( STATEalias0.POPULATION ) FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
+            "SELECT SUM( STATEalias0.POPULATION ) FROM BORDER_INFO AS BORDER_INFOalias0 , STATE AS STATEalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" AND STATEalias0.STATE_NAME = BORDER_INFOalias0.BORDER ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7396,20 +7396,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many major rivers cross var0",
+                "text": "how many major rivers cross state0",
                 "variables": {
-                    "var0": "ohio"
+                    "state0": "ohio"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 AND RIVERalias0.TRAVERSE = \"var0\" ;"
+            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > 750 AND RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "ohio",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7452,27 +7452,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what state borders the least states excluding var0 and excluding var1",
+                "text": "what state borders the least states excluding state0 and excluding state1",
                 "variables": {
-                    "var0": "alaska",
-                    "var1": "hawaii"
+                    "state0": "alaska",
+                    "state1": "hawaii"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 LEFT OUTER JOIN BORDER_INFO AS BORDER_INFOalias0 ON STATEalias0.STATE_NAME = BORDER_INFOalias0.STATE_NAME WHERE STATEalias0.STATE_NAME <> \"var0\" AND STATEalias0.STATE_NAME <> \"var1\" GROUP BY STATEalias0.STATE_NAME HAVING COUNT( BORDER_INFOalias0.BORDER ) = ( SELECT MIN( DERIVED_TABLEalias0.DERIVED_FIELDalias0 ) FROM ( SELECT COUNT( BORDER_INFOalias1.BORDER ) AS DERIVED_FIELDalias0 , STATEalias1.STATE_NAME FROM STATE AS STATEalias1 LEFT OUTER JOIN BORDER_INFO AS BORDER_INFOalias1 ON STATEalias1.STATE_NAME = BORDER_INFOalias1.STATE_NAME WHERE STATEalias1.STATE_NAME <> \"var0\" AND STATEalias1.STATE_NAME <> \"var1\" GROUP BY STATEalias1.STATE_NAME ) AS DERIVED_TABLEalias0 ) ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 LEFT OUTER JOIN BORDER_INFO AS BORDER_INFOalias0 ON STATEalias0.STATE_NAME = BORDER_INFOalias0.STATE_NAME WHERE STATEalias0.STATE_NAME <> \"state0\" AND STATEalias0.STATE_NAME <> \"state1\" GROUP BY STATEalias0.STATE_NAME HAVING COUNT( BORDER_INFOalias0.BORDER ) = ( SELECT MIN( DERIVED_TABLEalias0.DERIVED_FIELDalias0 ) FROM ( SELECT COUNT( BORDER_INFOalias1.BORDER ) AS DERIVED_FIELDalias0 , STATEalias1.STATE_NAME FROM STATE AS STATEalias1 LEFT OUTER JOIN BORDER_INFO AS BORDER_INFOalias1 ON STATEalias1.STATE_NAME = BORDER_INFOalias1.STATE_NAME WHERE STATEalias1.STATE_NAME <> \"state0\" AND STATEalias1.STATE_NAME <> \"state1\" GROUP BY STATEalias1.STATE_NAME ) AS DERIVED_TABLEalias0 ) ;"
         ],
         "variables": [
             {
                 "example": "alaska",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             },
             {
                 "example": "hawaii",
                 "location": "both",
-                "name": "var1",
+                "name": "state1",
                 "type": "state"
             }
         ]
@@ -7496,20 +7496,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the height of mount var0",
+                "text": "what is the height of mount mountain0",
                 "variables": {
-                    "var0": "mckinley"
+                    "mountain0": "mckinley"
                 }
             }
         ],
         "sql": [
-            "SELECT MOUNTAINalias0.MOUNTAIN_ALTITUDE FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.MOUNTAIN_NAME = \"var0\" ;"
+            "SELECT MOUNTAINalias0.MOUNTAIN_ALTITUDE FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.MOUNTAIN_NAME = \"mountain0\" ;"
         ],
         "variables": [
             {
                 "example": "mckinley",
                 "location": "both",
-                "name": "var0",
+                "name": "mountain0",
                 "type": "mountain"
             }
         ]
@@ -7552,20 +7552,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what mountains are in var0",
+                "text": "what mountains are in state0",
                 "variables": {
-                    "var0": "alaska"
+                    "state0": "alaska"
                 }
             }
         ],
         "sql": [
-            "SELECT MOUNTAINalias0.MOUNTAIN_NAME FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.STATE_NAME = \"var0\" ;"
+            "SELECT MOUNTAINalias0.MOUNTAIN_NAME FROM MOUNTAIN AS MOUNTAINalias0 WHERE MOUNTAINalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "alaska",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7603,27 +7603,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the largest state traversed by the var0 river",
+                "text": "what is the largest state traversed by the river0 river",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             },
             {
                 "question-split": "train",
-                "text": "what is the largest of the state that the var0 runs through",
+                "text": "what is the largest of the state that the river0 runs through",
                 "variables": {
-                    "var0": "rio grande"
+                    "river0": "rio grande"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.AREA = ( SELECT MAX( STATEalias1.AREA ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT RIVERalias1.TRAVERSE FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -7633,20 +7633,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many rivers run through the states bordering var0",
+                "text": "how many rivers run through the states bordering state0",
                 "variables": {
-                    "var0": "colorado"
+                    "state0": "colorado"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.TRAVERSE IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7656,20 +7656,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the longest river that does not run through var0",
+                "text": "what is the longest river that does not run through state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT DISTINCT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = (SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME NOT IN ( SELECT RIVERalias2.RIVER_NAME FROM RIVER AS RIVERalias2 WHERE RIVERalias2.TRAVERSE = \"var0\" ) ) AND RIVERalias0.RIVER_NAME NOT IN ( SELECT RIVERalias3.RIVER_NAME FROM RIVER AS RIVERalias3 WHERE RIVERalias3.TRAVERSE = \"var0\" ) ;"
+            "SELECT DISTINCT RIVERalias0.RIVER_NAME FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH = (SELECT MAX( RIVERalias1.LENGTH ) FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME NOT IN ( SELECT RIVERalias2.RIVER_NAME FROM RIVER AS RIVERalias2 WHERE RIVERalias2.TRAVERSE = \"state0\" ) ) AND RIVERalias0.RIVER_NAME NOT IN ( SELECT RIVERalias3.RIVER_NAME FROM RIVER AS RIVERalias3 WHERE RIVERalias3.TRAVERSE = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7754,34 +7754,34 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many cities are in var0",
+                "text": "how many cities are in state0",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many cities are in var0",
+                "text": "how many cities are in state0",
                 "variables": {
-                    "var0": "louisiana"
+                    "state0": "louisiana"
                 }
             },
             {
                 "question-split": "train",
-                "text": "how many cities does var0 have",
+                "text": "how many cities does state0 have",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "montana",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -7917,20 +7917,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many states border the var0 river",
+                "text": "how many states border the river0 river",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( DISTINCT BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" ) ;"
+            "SELECT COUNT( DISTINCT BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -8058,20 +8058,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "of the states washed by the var0 river which has the lowest point",
+                "text": "of the states washed by the river0 river which has the lowest point",
                 "variables": {
-                    "var0": "mississippi"
+                    "river0": "mississippi"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_ELEVATION = ( SELECT MIN( HIGHLOWalias1.LOWEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias1 , RIVER AS RIVERalias0 WHERE ( RIVERalias0.RIVER_NAME = \"var0\" ) AND ( RIVERalias0.TRAVERSE = HIGHLOWalias1.STATE_NAME ) ) ;"
+            "SELECT HIGHLOWalias0.STATE_NAME FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_ELEVATION = ( SELECT MIN( HIGHLOWalias1.LOWEST_ELEVATION ) FROM HIGHLOW AS HIGHLOWalias1 , RIVER AS RIVERalias0 WHERE ( RIVERalias0.RIVER_NAME = \"river0\" ) AND ( RIVERalias0.TRAVERSE = HIGHLOWalias1.STATE_NAME ) ) ;"
         ],
         "variables": [
             {
                 "example": "mississippi",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             }
         ]
@@ -8081,27 +8081,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many rivers in var1 are longer than the var0",
+                "text": "how many rivers in state0 are longer than the river0",
                 "variables": {
-                    "var0": "red",
-                    "var1": "texas"
+                    "river0": "red",
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > ALL ( SELECT RIVERalias1.LENGTH FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"var0\" ) AND RIVERalias0.TRAVERSE = \"var1\" ;"
+            "SELECT COUNT( RIVERalias0.RIVER_NAME ) FROM RIVER AS RIVERalias0 WHERE RIVERalias0.LENGTH > ALL ( SELECT RIVERalias1.LENGTH FROM RIVER AS RIVERalias1 WHERE RIVERalias1.RIVER_NAME = \"river0\" ) AND RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "red",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             },
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var1",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8167,27 +8167,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is state0",
                 "variables": {
-                    "var0": "new hampshire"
+                    "state0": "new hampshire"
                 }
             },
             {
                 "question-split": "train",
-                "text": "where is var0",
+                "text": "where is state0",
                 "variables": {
-                    "var0": "massachusetts"
+                    "state0": "massachusetts"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.COUNTRY_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"var0\" ;"
+            "SELECT STATEalias0.COUNTRY_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "new hampshire",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8239,20 +8239,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many cities named var0 are there in the usa",
+                "text": "how many cities named city0 are there in the usa",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"var0\" ;"
+            "SELECT COUNT( CITYalias0.CITY_NAME ) FROM CITY AS CITYalias0 WHERE CITYalias0.CITY_NAME = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "austin",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -8262,20 +8262,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many people live in the smallest state bordering var0",
+                "text": "how many people live in the smallest state bordering state0",
                 "variables": {
-                    "var0": "wyoming"
+                    "state0": "wyoming"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.POPULATION FROM STATE AS STATEalias0 WHERE STATEalias0.POPULATION = ( SELECT MAX( STATEalias1.POPULATION ) FROM STATE AS STATEalias1 WHERE STATEalias1.STATE_NAME IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ) AND STATEalias0.STATE_NAME IN ( SELECT BORDER_INFOalias1.BORDER FROM BORDER_INFO AS BORDER_INFOalias1 WHERE BORDER_INFOalias1.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "wyoming",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8285,27 +8285,27 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the length of the var0 river in var1",
+                "text": "what is the length of the river0 river in state0",
                 "variables": {
-                    "var0": "colorado",
-                    "var1": "texas"
+                    "river0": "colorado",
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT RIVERalias0.LENGTH FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"var0\" AND RIVERalias0.TRAVERSE = \"var1\" ;"
+            "SELECT RIVERalias0.LENGTH FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME = \"river0\" AND RIVERalias0.TRAVERSE = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "colorado",
                 "location": "both",
-                "name": "var0",
+                "name": "river0",
                 "type": "river"
             },
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var1",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8315,20 +8315,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the population density in the state with capital var0",
+                "text": "what is the population density in the state with capital city0",
                 "variables": {
-                    "var0": "austin"
+                    "city0": "austin"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.DENSITY FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ;"
+            "SELECT STATEalias0.DENSITY FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ;"
         ],
         "variables": [
             {
                 "example": "austin",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -8352,20 +8352,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what is the elevation of var0",
+                "text": "what is the elevation of low_point0",
                 "variables": {
-                    "var0": "death valley"
+                    "low_point0": "death valley"
                 }
             }
         ],
         "sql": [
-            "SELECT HIGHLOWalias0.LOWEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_POINT = \"var0\" ;"
+            "SELECT HIGHLOWalias0.LOWEST_ELEVATION FROM HIGHLOW AS HIGHLOWalias0 WHERE HIGHLOWalias0.LOWEST_POINT = \"low_point0\" ;"
         ],
         "variables": [
             {
                 "example": "death valley",
                 "location": "both",
-                "name": "var0",
+                "name": "low_point0",
                 "type": "low_point"
             }
         ]
@@ -8403,20 +8403,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what states border states that border states that border states that border var0",
+                "text": "what states border states that border states that border states that border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 , BORDER_INFO AS BORDER_INFOalias1 , BORDER_INFO AS BORDER_INFOalias2 , BORDER_INFO AS BORDER_INFOalias3 WHERE BORDER_INFOalias1.BORDER = BORDER_INFOalias0.STATE_NAME AND BORDER_INFOalias2.BORDER = BORDER_INFOalias1.STATE_NAME AND BORDER_INFOalias3.BORDER = BORDER_INFOalias2.STATE_NAME AND BORDER_INFOalias3.STATE_NAME = \"var0\" ;"
+            "SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 , BORDER_INFO AS BORDER_INFOalias1 , BORDER_INFO AS BORDER_INFOalias2 , BORDER_INFO AS BORDER_INFOalias3 WHERE BORDER_INFOalias1.BORDER = BORDER_INFOalias0.STATE_NAME AND BORDER_INFOalias2.BORDER = BORDER_INFOalias1.STATE_NAME AND BORDER_INFOalias3.BORDER = BORDER_INFOalias2.STATE_NAME AND BORDER_INFOalias3.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8426,20 +8426,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "how many states border on the state whose capital is var0",
+                "text": "how many states border on the state whose capital is city0",
                 "variables": {
-                    "var0": "boston"
+                    "city0": "boston"
                 }
             }
         ],
         "sql": [
-            "SELECT COUNT( BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"var0\" ) ;"
+            "SELECT COUNT( BORDER_INFOalias0.BORDER ) FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = ( SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.CAPITAL = \"city0\" ) ;"
         ],
         "variables": [
             {
                 "example": "boston",
                 "location": "both",
-                "name": "var0",
+                "name": "city0",
                 "type": "city"
             }
         ]
@@ -8449,20 +8449,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "what are the major cities in the states through which the major river in var0 runs",
+                "text": "what are the major cities in the states through which the major river in state0 runs",
                 "variables": {
-                    "var0": "virginia"
+                    "state0": "virginia"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME IN ( SELECT RIVERalias1.RIVER_NAME FROM RIVER AS RIVERalias1 WHERE RIVERalias1.LENGTH > 750 AND RIVERalias1.TRAVERSE = \"var0\" ) ) ;"
+            "SELECT CITYalias0.CITY_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION > 150000 AND CITYalias0.STATE_NAME IN ( SELECT RIVERalias0.TRAVERSE FROM RIVER AS RIVERalias0 WHERE RIVERalias0.RIVER_NAME IN ( SELECT RIVERalias1.RIVER_NAME FROM RIVER AS RIVERalias1 WHERE RIVERalias1.LENGTH > 750 AND RIVERalias1.TRAVERSE = \"state0\" ) ) ;"
         ],
         "variables": [
             {
                 "example": "virginia",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8472,20 +8472,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "which states does not border var0",
+                "text": "which states does not border state0",
                 "variables": {
-                    "var0": "texas"
+                    "state0": "texas"
                 }
             }
         ],
         "sql": [
-            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME NOT IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"var0\" ) ;"
+            "SELECT STATEalias0.STATE_NAME FROM STATE AS STATEalias0 WHERE STATEalias0.STATE_NAME NOT IN ( SELECT BORDER_INFOalias0.BORDER FROM BORDER_INFO AS BORDER_INFOalias0 WHERE BORDER_INFOalias0.STATE_NAME = \"state0\" ) ;"
         ],
         "variables": [
             {
                 "example": "texas",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]
@@ -8509,20 +8509,20 @@
         "sentences": [
             {
                 "question-split": "train",
-                "text": "which state is the largest city in var0 in",
+                "text": "which state is the largest city in state0 in",
                 "variables": {
-                    "var0": "montana"
+                    "state0": "montana"
                 }
             }
         ],
         "sql": [
-            "SELECT CITYalias0.STATE_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"var0\" ) AND CITYalias0.STATE_NAME = \"var0\" ;"
+            "SELECT CITYalias0.STATE_NAME FROM CITY AS CITYalias0 WHERE CITYalias0.POPULATION = ( SELECT MAX( CITYalias1.POPULATION ) FROM CITY AS CITYalias1 WHERE CITYalias1.STATE_NAME = \"state0\" ) AND CITYalias0.STATE_NAME = \"state0\" ;"
         ],
         "variables": [
             {
                 "example": "montana",
                 "location": "both",
-                "name": "var0",
+                "name": "state0",
                 "type": "state"
             }
         ]


### PR DESCRIPTION
GeoQuery variables were just 'varN', this changes them to specify the type and be of the form 'typeN' instead.